### PR TITLE
Workaround SPI issue on Pi

### DIFF
--- a/services/rfid/package.json
+++ b/services/rfid/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index"
+    "start":
+      "/usr/bin/raspi-config nonint do_spi 1 && /usr/bin/raspi-config nonint do_spi 0 && node index"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
After reboot the SPI interface on the Pi seems to be enabled yet no messages arrive from the card reader. The workaround seems to be disabling SPI using `raspi-config` and enabling it again before starting the service.

I tried doing this using a `ExecStartPre=` flag in systemd but this didn't work.