### PR TITLE
Follow app symlinks

### DIFF
--- a/services/manager/lib/apps/index.js
+++ b/services/manager/lib/apps/index.js
@@ -4,15 +4,13 @@ const path = require('path');
 const isDirectory = ({ path }) => fs.lstatSync(path).isDirectory();
 const isNotHiddenDirectory = ({ path }) => path[0] !== '.';
 
-const getDirectories = source => (
-  fs.readdirSync(source)
+const getDirectories = source =>
+  fs
+    .readdirSync(source)
     .map(name => ({ path: path.join(source, name), name }))
     .filter(isDirectory)
-    .filter(isNotHiddenDirectory)
-);
+    .filter(isNotHiddenDirectory);
 
-const appNamesToMount = appPath => (
-  getDirectories(appPath)
-);
+const appNamesToMount = appPath => getDirectories(appPath);
 
 module.exports = appNamesToMount;

--- a/services/manager/lib/apps/index.js
+++ b/services/manager/lib/apps/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const isDirectory = ({ path }) => fs.lstatSync(path).isDirectory();
+const isDirectory = ({ path }) => fs.statSync(path).isDirectory();
 const isNotHiddenDirectory = ({ path }) => path[0] !== '.';
 
 const getDirectories = source =>


### PR DESCRIPTION
A bit of a noisy PR because of Prettier formatting the code. The only effective change is on line 4.

This allows a directory symlinked in `apps` e.g. `apps/secret-project -> ../../../secret` to be mounted by the manager.