### PR TITLE
Disables physical service to prevent DAC bug

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -51,7 +51,8 @@ systemctl daemon-reload
 systemctl start manager
 systemctl enable manager
 systemctl enable manager-web-server
-systemctl enable physical
+# TODO: Investigate why this causes DAC to stop working
+# systemctl enable physical
 systemctl enable rfid
 
 echo "*** IPTables (Port forwarding)"


### PR DESCRIPTION
Enabling the physical service stops sound output
through a connected DAC. Disabling until we figure
out how to solve it.