### PR TITLE
DAC and Physical UI interferance

### DIFF
--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -39,8 +39,28 @@ function eachItem(config, cb) {
     )
 }
 
+
+function collectPinNumbers(config) {
+  const pins = [];
+
+  eachItem(config, (type, spec) => {
+    if (spec.config && spec.config.pin) {
+      pins.push(spec.config.pin);
+    } else if (spec.config && spec.config.pins) {
+      pins.push(...Object.values(spec.config.pins));
+    }
+  });
+
+  return pins;
+}
+
 module.exports.create = function (router) {
-  const io = new IO({ enableSoftPwm: true });
+  const io = new IO({
+    enableSoftPwm: true,
+    // Only enable pins used in the config
+    // to avoid clashing with other components
+    includePins: collectPinNumbers(uiConfig)
+  });
 
   var board = new five.Board({
     io: io,

--- a/services/physical/package.json
+++ b/services/physical/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "board-io": "^3.0.5",
     "faye-websocket": "^0.11.0",
-    "johnny-five": "^0.10.10"
+    "johnny-five": "^0.13.0"
   },
   "optionalDependencies": {
     "raspi-rotary-encoder": "andrewn/raspi-rotary-encoder",


### PR DESCRIPTION
When the `phsyical` service is started, no sound comes out of the Phat DAC.

Although the Phat DAC and the Radiodan Classic PCB do not share any pins, the default behaviour of [JohnnyFive](http://johnny-five.io/) and [Raspi-io](https://github.com/nebrius/raspi-io) is to innitialise all the GPIO pins to known states and this conflicts with the DAC pins.

[The fix in this commit](https://github.com/andrewn/neue-radio/commit/3f7df7b60f35289df55c4dcddf841791fe0dddd9) ensures that only pins we are actually using in the `physical` service config ([example](https://github.com/andrewn/neue-radio/blob/3f7df7b60f35289df55c4dcddf841791fe0dddd9/services/physical/config/physical-config.json)) are initialised.

Now, sound works *but* it plays at a slow speed. That's probably a conflict with the `pigpio` library used by Raspi-io, as indicated in [this FAQ](http://abyz.me.uk/rpi/pigpio/faq.html#Sound_isnt_working).