### PR TITLE
Configures pigpio to use the PWM pin and not the PCM pins (fixes slow playback speed)

### DIFF
--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -1,4 +1,5 @@
 var five = require('johnny-five');
+var pigpio = require('pigpio');
 var EchoIO = require('./echo-io');
 
 var IO = null;
@@ -54,7 +55,13 @@ function collectPinNumbers(config) {
   return pins;
 }
 
+
 module.exports.create = function (router) {
+  // Tells the underlying gpio library to use the
+  // PWM pin as a clock source, rather than the PCM
+  // pin that provides I2S audio to DACs
+  pigpio.configureClock(5 /* pigpio's default duty cycle */, pigpio.CLOCK_PWM);
+
   const io = new IO({
     enableSoftPwm: true,
     // Only enable pins used in the config


### PR DESCRIPTION
As noted in #23, the `physical` service was working with a connected I2S DAC, but any sound playback was really slow.

This was because of the [reason given here](http://abyz.me.uk/rpi/pigpio/faq.html#Sound_isnt_working). `pigpio` is used by `Raspi-io`. The fix was to configure `pigpio` to use the PWM pin as a clock source and not a PCM pin before we create the `Raspi-io` instance.

Sound playback is now at actual speed.