### PR TITLE
Add logrotate defaults

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -12,6 +12,33 @@ echo "*** Prerequisites"
 apt-get install git -y
 # apt-get upgrade -y
 
+echo "*** logrotate"
+
+/bin/cat <<EOF >/etc/logrotate.conf
+daily
+rotate 4
+create
+minsize 1k
+size 100M
+compress
+
+include /etc/logrotate.d
+
+/var/log/wtmp {
+    missingok
+    monthly
+    create 0664 root utmp
+    rotate 1
+}
+
+/var/log/btmp {
+    missingok
+    monthly
+    create 0660 root utmp
+    rotate 1
+}
+EOF
+
 echo "*** Chrome"
 cd /tmp
 # https://launchpad.net/~osomon/+archive/ubuntu/chromium-dev/


### PR DESCRIPTION
These changes are in response to issues with logs filling our SD cards.

This `logrotate` config is a clone of the default pi config, with a few
additions:

* rotate daily
* create new files, with a minimum size of 1k (to prevent truncation
issues)
* set a maximum size of 100MB, rotated up to 4 times a day before deletion
* compress old files