### PR TITLE
Add conditional start for radiodan services

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -34,6 +34,9 @@ ln -sf /opt/node/bin/npm /usr/local/bin/npm
 
 echo "*** Radiodan"
 mkdir -p /opt/radiodan
+mkdir -p /opt/radiodan/processes/services
+touch /opt/radiodan/processes/services/{downloader,rfid,physical}
+
 cd /opt/radiodan
 git clone https://github.com/andrewn/neue-radio rde
 cd rde/services/manager

--- a/deployment/systemd/downloader.service
+++ b/deployment/systemd/downloader.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=YouTube Downloader
+ConditionPathExists=/opt/radiodan/processes/services/downloader
 
 [Service]
 WorkingDirectory=/opt/radiodan/rde/services/downloader

--- a/deployment/systemd/physical.service
+++ b/deployment/systemd/physical.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Physical interface
+ConditionPathExists=/opt/radiodan/processes/services/physical
 
 [Service]
 WorkingDirectory=/opt/radiodan/rde/services/physical

--- a/deployment/systemd/rfid.service
+++ b/deployment/systemd/rfid.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=RFID reader on SPI Interface
+ConditionPathExists=/opt/radiodan/processes/services/rfid
 
 [Service]
 WorkingDirectory=/opt/radiodan/rde/services/rfid


### PR DESCRIPTION
These `systemd` services are configured to only start when a [certain path exists][1]:

> With ConditionPathExists= a file existence condition is checked before
> a unit is started. If the specified absolute path name does not exist,
> the condition will fail.

The new default configuration will create all the paths requried to start
everything. Simply rename or delete the files to prevent the services
from running.

The next stage will be to create a process that manages this file
creation, via a web interface.

[1]:https://www.freedesktop.org/software/systemd/man/systemd.unit.html