### PR TITLE
Add single app support to manager

### DIFF
--- a/services/manager/index.js
+++ b/services/manager/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const findApps = require('./lib/apps');
+const { findApps, singleApp } = require('./lib/apps');
 const http = require('./lib/io/http');
 const mountWebSocket = require('./lib/io/ws');
 
@@ -11,7 +11,7 @@ const externalPort = process.env.EXTERNAL_PORT || 5000;
 const appPath = path.resolve(__dirname, '..', '..', 'apps');
 const managerPublicPath = path.join(__dirname, 'public');
 
-const apps = findApps(appPath);
+const apps = process.env.APP_PATH ? singleApp(process.env.APP_PATH) : findApps(appPath);
 
 http.mountExternal(apps, externalPort);
 http.mountInternal(apps, internalPort, managerPublicPath);

--- a/services/manager/lib/apps/index.js
+++ b/services/manager/lib/apps/index.js
@@ -4,13 +4,19 @@ const path = require('path');
 const isDirectory = ({ path }) => fs.statSync(path).isDirectory();
 const isNotHiddenDirectory = ({ path }) => path[0] !== '.';
 
-const getDirectories = source =>
+const findApps = source => (
   fs
     .readdirSync(source)
     .map(name => ({ path: path.join(source, name), name }))
     .filter(isDirectory)
-    .filter(isNotHiddenDirectory);
+    .filter(isNotHiddenDirectory)
+);
 
-const appNamesToMount = appPath => getDirectories(appPath);
+const singleApp = appPath => (
+  [{ path: appPath, name: path.posix.basename(appPath) }]
+    .filter(isDirectory)
+    .filter(isNotHiddenDirectory)
+);
 
-module.exports = appNamesToMount;
+module.exports.findApps = findApps;
+module.exports.singleApp = singleApp;


### PR DESCRIPTION
The default setting for manager is to load every app it can find in a
given path.

If a `APP_PATH` environment variable is set, the manager will attempt to
mount just that single application.