### PR TITLE
Allows audio/video playback without user gesture

### DIFF
--- a/services/manager/start-web-environment.sh
+++ b/services/manager/start-web-environment.sh
@@ -2,7 +2,7 @@
 
 REMOTE_DEBUGGING_ADDRESS=0.0.0.0
 APP_URL=http://localhost:${INTERNAL_PORT}/
-ARGS="--disable-gpu --use-fake-ui-for-media-stream --remote-debugging-port=${REMOTE_DEBUGGING_PORT} --remote-debugging-address=${REMOTE_DEBUGGING_ADDRESS} $APP_URL"
+ARGS="--disable-gpu --use-fake-ui-for-media-stream --autoplay-policy=no-user-gesture-required --remote-debugging-port=${REMOTE_DEBUGGING_PORT} --remote-debugging-address=${REMOTE_DEBUGGING_ADDRESS} $APP_URL"
 
 MACOS_CHROME=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
 


### PR DESCRIPTION
This disables the new autoplay policy in Chrome 66 that requires a user gesture before video and audio can be played back including Web Audio.