### PR TITLE
Physical capacitive touch: Reset and sensitivity control

### DIFF
--- a/services/physical/config/cap-config.example.json
+++ b/services/physical/config/cap-config.example.json
@@ -2,7 +2,9 @@
   "Capacitive": [
     {
       "id": "cap",
-      "config": {}
+      "config": {
+        "resetPin": 0
+      }
     }
   ]
 }

--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -201,9 +201,7 @@ function createEncoderInstance(spec, routable) {
 }
 
 function createCapInstance(spec, routable) {
-  console.log("pre cap setup");
   connectRaspiCap().then(cap => {
-    console.log("cap connected");
     cap.on("change", function(evt) {
       routable.publish("change", evt);
     });

--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -1,53 +1,46 @@
-var five = require('johnny-five');
-var pigpio = require('pigpio');
-var EchoIO = require('./echo-io');
+var five = require("johnny-five");
+var pigpio = require("pigpio");
+var EchoIO = require("./echo-io");
 
 var IO = null;
 var RotaryEncoder;
 var connectRaspiCap;
 
 try {
-  IO = require('raspi-io');
-} catch(err) {
-  console.error('Raspi-io not found, falling back to EchoIO');
+  IO = require("raspi-io");
+} catch (err) {
+  console.error("Raspi-io not found, falling back to EchoIO");
   console.error(err);
   IO = EchoIO;
 }
 
 try {
-  RotaryEncoder = require('raspi-rotary-encoder').RotaryEncoder
-} catch(err) {
-  console.error('raspi-rotary-encoder not found, falling back to mock');
+  RotaryEncoder = require("raspi-rotary-encoder").RotaryEncoder;
+} catch (err) {
+  console.error("raspi-rotary-encoder not found, falling back to mock");
   console.error(err);
-  RotaryEncoder = function () {
+  RotaryEncoder = function() {
     return {
-      on: function () {}
-    }
+      on: function() {}
+    };
   };
 }
 
 try {
-  connectRaspiCap = require('raspi-cap').connect;
-} catch(err) {
-  console.error('raspi-cap not found, falling back to mock');
+  connectRaspiCap = require("raspi-cap").connect;
+} catch (err) {
+  console.error("raspi-cap not found, falling back to mock");
   console.error(err);
-  connectRaspiCap = function () {
+  connectRaspiCap = function() {
     return new Promise.resolve({ on: () => {} });
   };
 }
 
 function eachItem(config, cb) {
-  Object
-    .entries(config)
-    .forEach(
-      ([type, items = []]) => {
-        items.forEach(
-          item => cb(type, item)
-        )
-      }
-    )
+  Object.entries(config).forEach(([type, items = []]) => {
+    items.forEach(item => cb(type, item));
+  });
 }
-
 
 function collectPinNumbers(config) {
   const pins = [];
@@ -63,8 +56,7 @@ function collectPinNumbers(config) {
   return pins;
 }
 
-
-module.exports.create = function (router, uiConfig) {
+module.exports.create = function(router, uiConfig) {
   // Tells the underlying gpio library to use the
   // PWM pin as a clock source, rather than the PCM
   // pin that provides I2S audio to DACs
@@ -83,44 +75,38 @@ module.exports.create = function (router, uiConfig) {
   });
 
   var factories = {
-    'Button': createButtonInstance,
-    'Led.RGB': createLedRGBInstance,
-    'Encoder': createEncoderInstance,
-    'Capacitive': createCapInstance
+    Button: createButtonInstance,
+    "Led.RGB": createLedRGBInstance,
+    Encoder: createEncoderInstance,
+    Capacitive: createCapInstance
   };
 
   var types = Object.keys(factories);
 
   var instances = {};
-  types.forEach(function (type) {
+  types.forEach(function(type) {
     instances[type] = {};
   });
 
-  board.on('ready', function() {
-    console.log('Board is ready');
+  board.on("ready", function() {
+    console.log("Board is ready");
 
-    eachItem(
-      uiConfig, 
-      (type, spec) => {
-        const factory = factories[type];
+    eachItem(uiConfig, (type, spec) => {
+      const factory = factories[type];
 
-        if (spec && factory) {
-          const routable = router.register(type, spec.id);
-          instances[type][spec.id] = factory(spec, routable);
-        } else {
-          console.error("No config or factory for component type: ", type);
-        }
+      if (spec && factory) {
+        const routable = router.register(type, spec.id);
+        instances[type][spec.id] = factory(spec, routable);
+      } else {
+        console.error("No config or factory for component type: ", type);
       }
-    );
+    });
 
     if (this.repl) {
-      this.repl.inject(Object.assign(
-        { io: io, five: five },
-        instances
-      ));
+      this.repl.inject(Object.assign({ io: io, five: five }, instances));
     }
   });
-}
+};
 
 function createButtonInstance(spec, routable) {
   const id = spec.id;
@@ -129,22 +115,22 @@ function createButtonInstance(spec, routable) {
   const button = new five.Button(Object.assign({ id: id }, config));
 
   button.on("press", function() {
-    console.log( id + ": Button pressed" );
-    routable.publish('press', { pressed: true });
+    console.log(id + ": Button pressed");
+    routable.publish("press", { pressed: true });
   });
 
   button.on("hold", function() {
-    console.log( id + ": Button held" );
-    routable.publish('hold', { pressed: true, durationMs: button.holdtime });
+    console.log(id + ": Button held");
+    routable.publish("hold", { pressed: true, durationMs: button.holdtime });
   });
 
   button.on("release", function() {
-    console.log( id + ": Button released" );
-    routable.publish('release', { pressed: false });
+    console.log(id + ": Button released");
+    routable.publish("release", { pressed: false });
   });
 
   return button;
-};
+}
 
 function createLedRGBInstance(spec, routable) {
   const id = spec.id;
@@ -163,12 +149,12 @@ function createLedRGBInstance(spec, routable) {
   //
   // worker.ready();
 
-  routable.on('request', function (req) {
+  routable.on("request", function(req) {
     var stateChangePromise;
 
-    console.log('RGBLED request', req);
+    console.log("RGBLED request", req);
 
-    switch(req.command) {
+    switch (req.command) {
       // case 'change':
       //   req.params.queue = req.params.queue || [];
       //
@@ -179,7 +165,7 @@ function createLedRGBInstance(spec, routable) {
       //     })
       //   );
       //   break;
-      case 'status':
+      case "status":
         stateChangePromise = Promise.resolve({ color: rgb.color() });
         break;
       default:
@@ -187,18 +173,15 @@ function createLedRGBInstance(spec, routable) {
           rgb.color(req.params.color);
         }
         if (req.params.on != null) {
-          (req.params.on === true) ? rgb.on() : rgb.off();
+          req.params.on === true ? rgb.on() : rgb.off();
         }
         stateChangePromise = Promise.resolve();
     }
 
-    stateChangePromise.then(
-      function () {
-        // TODO: Do we want to allow responses?
-        // worker.respond(req.sender, req.correlationId, {error: false});
-      }
-    );
-
+    stateChangePromise.then(function() {
+      // TODO: Do we want to allow responses?
+      // worker.respond(req.sender, req.correlationId, {error: false});
+    });
   });
 
   return rgb;
@@ -212,19 +195,17 @@ function createEncoderInstance(spec, routable) {
   const encoder = new RotaryEncoder(Object.assign({ id: id }, config));
 
   // the encoder will try to work out where in the loop you are
-  encoder.on('change', function (evt) {
-    routable.publish('turn', evt);
+  encoder.on("change", function(evt) {
+    routable.publish("turn", evt);
   });
 }
 
 function createCapInstance(spec, routable) {
-  console.log('pre cap setup');
-  connectRaspiCap().then(
-    cap => {
-      console.log('cap connected');
-      cap.on('change', function (evt) {
-        routable.publish('change', evt);
-      });
-    }
-  );
+  console.log("pre cap setup");
+  connectRaspiCap().then(cap => {
+    console.log("cap connected");
+    cap.on("change", function(evt) {
+      routable.publish("change", evt);
+    });
+  });
 }

--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -211,6 +211,19 @@ function createCapInstance(spec, routable) {
       }
     });
 
+    routable.on("statusRequest", function() {
+      routable.publish("status", { sensitivty: cap.getSensitivity() });
+    });
+
+    routable.on("sensitivity", function(req) {
+      try {
+        cap.setSensitivity(req.params.level);
+        routable.publish("status", { sensitivty: cap.getSensitivity() });
+      } catch (e) {
+        console.error(e);
+      }
+    });
+
     cap.on("reset", function() {
       routable.publish("reset", {});
     });

--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -201,7 +201,20 @@ function createEncoderInstance(spec, routable) {
 }
 
 function createCapInstance(spec, routable) {
-  connectRaspiCap().then(cap => {
+  connectRaspiCap({ resetPin: spec.config.resetPin }).then(cap => {
+    // Listen for messages from clients
+    routable.on("resetRequest", function() {
+      try {
+        cap.reset();
+      } catch (e) {
+        console.error(e);
+      }
+    });
+
+    cap.on("reset", function() {
+      routable.publish("reset", {});
+    });
+
     cap.on("change", function(evt) {
       routable.publish("change", evt);
     });

--- a/services/physical/lib/ws.js
+++ b/services/physical/lib/ws.js
@@ -1,4 +1,4 @@
-const createWebsocket = require('websocket');
+const createWebsocket = require('websocket').default;
 
 const webSocket = (router) => {
   const ws = createWebsocket();

--- a/services/physical/package-lock.json
+++ b/services/physical/package-lock.json
@@ -1226,10 +1226,12 @@
       "integrity": "sha512-M5xiRNuYwGAHU2fwN4ppiKEbM9+/tw+NGwLLMJqRtyNBrTDc6aU6Bt0xTHU1ZgcMzYFpwsdi/FOI+yGKICm2Rw=="
     },
     "raspi-cap": {
-      "version": "github:andrewn/raspi-cap#e5ac9fc67b904245a8a638e01d5b379d435cadc4",
-      "optional": true,
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/raspi-cap/-/raspi-cap-0.0.5.tgz",
+      "integrity": "sha512-zaPbonwtmatgu+DA7giURthl+vzXbT1AT8eWnpMgtLtRbth/6AJBhWTSHO/LTznHhOurWkX037h8m7lkoBLYhA==",
       "requires": {
         "raspi": "5.0.2",
+        "raspi-gpio": "5.0.0",
         "raspi-i2c": "6.1.0"
       }
     },
@@ -1237,7 +1239,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/raspi-gpio/-/raspi-gpio-5.0.0.tgz",
       "integrity": "sha512-vI9hT+HoZNRxVgthn3Gdr67DUNYxzNCJumPRts7O6o599524iPMmXw4EUUzErvKmyte41ENdlMtEFIvNijEV8Q==",
-      "optional": true,
       "requires": {
         "pigpio": "0.6.4",
         "raspi-board": "5.1.0",

--- a/services/physical/package.json
+++ b/services/physical/package.json
@@ -14,7 +14,7 @@
     "faye-websocket": "^0.11.0",
     "ip": "^1.1.5",
     "johnny-five": "^0.13.0",
-    "raspi-cap": "github:andrewn/raspi-cap#0.0.2",
+    "raspi-cap": "^0.0.5",
     "websocket": "../../shared/websocket"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This adds support for some more advanced features of the capacitive touch board. 

## Reset (92032571354edfc5c0af4579ad73c9865bbce0a5)
Resetting the board re-calibrates the sensors which is very useful when moving wires.

`Capacitive/:id/resetRequest` will perform the reset.
`Capacitive/:id/reset` is emitted when a reset occurs.

## Getting/setting sensitivity (982e125a81fcd6bd3cbeef5ee5207adae834c72b)

Allows an app to change how sensitive the board is to touches.

`Capacitive/:id/statusRequest` request the sensitivity.
`Capacitive/:id/status` emits a payload of `{ sensitivity: NUMBER }`

To change the sensitivity send, `Capacitive/:id/sensitivity` with a payload `{ params: { level: NUMBER } }`. `Capacitive/:id/status` is emitted when the sensitivity changes.

## Message routing

~As discussed, it'd be nice to have some library support and some naming conventions and patterns for this stuff to apply across the `services` and `apps`. I like the patterrn of being able to send a command to a service  (e.g. `sensitivity`) and know that it has been executed, or failed with an error. But also for other parts of the system to listen for events (`status`).~

This has been re-based onto the new WebSocket library from #40.

