### PR TITLE
Speechd bridge (Python)

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -59,6 +59,9 @@ ln -sf /opt/node/bin/node /usr/local/bin/node
 ln -sf /opt/node/bin/npm /usr/local/bin/npm
 /opt/node/bin/npm config set prefix /usr/local
 
+echo "*** Speech"
+apt-get install flite speech-dispatcher python3-speechd python3-websockets
+
 echo "*** Radiodan"
 mkdir -p /opt/radiodan
 mkdir -p /opt/radiodan/processes/services
@@ -91,6 +94,7 @@ systemctl enable manager-web-server
 # systemctl enable physical
 systemctl enable rfid
 systemctl enable debug
+systemctl enable speech
 
 echo "*** IPTables (Port forwarding)"
 DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages iptables-persistent

--- a/deployment/systemd/speech.service
+++ b/deployment/systemd/speech.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=speechd to WebSocket bridge
+ConditionPathExists=/opt/radiodan/processes/services/speech
+
+[Service]
+EnvironmentFile=/opt/radiodan/rde/deployment/systemd/ports.env
+WorkingDirectory=/opt/radiodan/rde/services/speech
+ExecStart=/usr/bin/env WS_PORT=${MANAGER_WEBSOCKET_PORT} python3 main.py
+Restart=on-failure
+StandardOutput=syslog
+SyslogIdentifier=rde-speechd
+Type=idle
+
+[Install]
+WantedBy=multi-user.target

--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -1,0 +1,24 @@
+# Speech Dispatcher Service
+
+A tiny service that can speak under WebSocket control. This communicates using a [`speech-dispatcher`](https://devel.freebsoft.org/doc/speechd/speech-dispatcher.html) instance using their own [Python API bindings](https://devel.freebsoft.org/doc/speechd/speech-dispatcher.html#Python-API).
+
+## Installation
+
+Requires `python3.5+`:
+
+On Debian-based systems:
+
+    sudo apt-get install speech-dispatcher python3-speechd python3-websockets
+
+## Running
+
+    WS_HOST=raspberrypi.local WS_PORT=8000 python3 main.py
+
+`WS_PORT` is mandatory. The host IP is used if `WS_HOST` is not supplied.
+
+## Protocol
+
+| topic                | payload                        |
+| -------------------- | ------------------------------ |
+| speech.command.speak | { utterance: 'Hello, world!' } |
+| speech.event.spoken  | { utterance: 'Hello, world!' } |

--- a/services/speech/main.py
+++ b/services/speech/main.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import os
+import signal
+import socket
+import sys
+
+from soapbox.connection import connect_and_handle_messages
+from soapbox.handler import MessageHandler
+
+WS_HOST = os.getenv('WS_HOST', socket.gethostbyname(socket.gethostname()))
+WS_PORT = os.getenv('WS_PORT', None)
+DEBUG = os.getenv('DEBUG', False)
+
+if WS_PORT == None:
+    print("WS_PORT must be supplied as environment variable")
+    sys.exit(1)
+
+loop = asyncio.get_event_loop()
+
+if DEBUG:
+    import logging
+    logging.getLogger('asyncio').setLevel(logging.DEBUG)
+    loop.set_debug(True)
+
+# The term_signal future is completed when receiving SIGTERM or SIGINT
+term_signal = asyncio.Future()
+loop.add_signal_handler(signal.SIGTERM, term_signal.set_result, None)
+loop.add_signal_handler(signal.SIGINT, term_signal.set_result, None)
+
+
+async def main():
+    try:
+        handler = MessageHandler()
+
+        connection = asyncio.ensure_future(
+            connect_and_handle_messages(
+                WS_HOST, WS_PORT, handler.handle_message)
+        )
+
+        # Wait for either the `connection` or `term_signal` future to complete
+        # connection completing means that the WS connection has been closed
+        # term_signal completing means an OS signal has been received
+        await asyncio.wait((connection, term_signal), return_when=asyncio.FIRST_COMPLETED)
+
+    finally:
+        print("clean up")
+        handler.close()
+        connection.cancel()
+
+
+loop.run_until_complete(main())

--- a/services/speech/soapbox/connection.py
+++ b/services/speech/soapbox/connection.py
@@ -1,0 +1,40 @@
+import asyncio
+import websockets
+
+from soapbox.message import Message
+
+
+def connect(host, port):
+    return websockets.connect('ws://' + host + ':' + port)
+
+
+async def connect_and_handle_messages(host, port, handler):
+    websocket = await connect(host, port)
+    print("connected")
+    while True:
+        try:
+            data = await websocket.recv()
+        except websockets.exceptions.ConnectionClosed:
+            print("connection has closed")
+            raise
+
+        message = None
+        response = None
+
+        try:
+            message = Message.from_json(data)
+        except:
+            print("invalid message")
+
+        if message != None:
+            try:
+                response = handler(message)
+            except:
+                print("error handling message")
+
+        if response != None:
+            try:
+                await websocket.send(response.to_json())
+            except:
+                print("error sending response")
+                pass

--- a/services/speech/soapbox/handler.py
+++ b/services/speech/soapbox/handler.py
@@ -1,0 +1,19 @@
+from soapbox.speech import Speech
+from soapbox.message import Message
+
+
+class MessageHandler:
+    def __init__(self):
+        self.speech = Speech()
+
+    def handle_message(self, message):
+        if message.topic == 'speech.command.speak':
+            print(message.payload['utterance'])
+            self.speech.speak(message.payload['utterance'])
+            return Message(
+                'speech.event.spoken',
+                {'utterance': message.payload['text']}
+            )
+
+    def close(self):
+        self.speech.destroy()

--- a/services/speech/soapbox/message.py
+++ b/services/speech/soapbox/message.py
@@ -1,0 +1,22 @@
+import json
+
+
+class Message:
+    @staticmethod
+    def from_json(raw):
+        try:
+            data = json.loads(raw)
+            return Message(data['topic'], data['payload'])
+        except:
+            message = {}
+
+    def __init__(self, topic, payload={}):
+
+        self.topic = topic
+        self.payload = payload
+
+        if self.topic == None:
+            raise ValueError('Not a valid topic')
+
+    def to_json(self):
+        return json.dumps({'topic': self.topic, 'payload': self.payload})

--- a/services/speech/soapbox/speech.py
+++ b/services/speech/soapbox/speech.py
@@ -1,0 +1,18 @@
+import speechd
+
+
+class Speech:
+    def __init__(self):
+        self.client = speechd.SSIPClient('test')
+
+        self.client.set_output_module('festival')
+        self.client.set_language('en')
+        self.client.set_punctuation(speechd.PunctuationMode.SOME)
+
+    def speak(self, str):
+        self.client.speak(str)
+
+    # Calling this close() causes it not to be
+    # found
+    def destroy(self):
+        self.client.close()

--- a/services/speech/test.html
+++ b/services/speech/test.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test speechd-service</title>
+</head>
+
+<body>
+  <input type="text" placeholder="Say something" />
+  <button>Speak!</button>
+  <script>
+    function wsUrl(search = window.location.search) {
+      const params = new URLSearchParams(search);
+      const host = params.get('host') || window.location.hostname;
+      const port = params.get('port') || window.location.port;
+
+      return `ws://${host}:${port}`;
+    }
+
+    function connect(url) {
+      const ws = new WebSocket(url);
+      ws.onopen = () => console.log('WS opened');
+      ws.onclose = () => console.warn('WS closed');
+      ws.onmessage = (evt) => console.info('> ', evt.data);
+
+      return {
+        send: (topic, payload) => ws.send(JSON.stringify({ topic, payload }))
+      };
+    }
+
+    const send = connect(wsUrl()).send;
+
+    const speak = function () {
+      const utterance = document.querySelector('input').value;
+      send('speech.command.speak', { utterance });
+    }
+
+    document.querySelector('button').addEventListener(
+      'click',
+      speak
+    );
+
+    document.querySelector('input').addEventListener(
+      'keyup',
+      function (evt) {
+        if (evt.keyCode === 13 /* ENTER */) {
+          speak();
+        }
+      }
+    );
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Listens on our shared WebSocket broker and communicates with a [`speech-dispatcher`](https://devel.freebsoft.org/doc/speechd/speech-dispatcher.html) instance. See [README](https://github.com/andrewn/neue-radio/compare/feature/speak-to-me?expand=1#diff-79baaa2333c88a9e03c42ef40fb5a0ef) for available commands.

This is written in Python3 and uses `speechd`'s own [Python API bindings](https://devel.freebsoft.org/doc/speechd/speech-dispatcher.html#Python-API) and uses [`asyncio`](https://docs.python.org/3/library/asyncio.html).

The alternative would be to use with `node.js` and communicate directly with `speechd` via their text-based protocol over a UNIX domain socket. That seems to be more work but perhaps the resulting code would be easier to maintain?


