### PR TITLE
Support for other speech servers

### DIFF
--- a/services/speech/src/main.js
+++ b/services/speech/src/main.js
@@ -5,9 +5,11 @@ const log = require("debug")("speechd:main");
 const connectToSpeechd = require("./speechd");
 const handleMessage = require("./handleMessage");
 
+const autoSpawn = !!process.env.NO_AUTO_SPAWN;
+
 const main = async () => {
   try {
-    const speech = await connectToSpeechd({ autoSpawn: true });
+    const speech = await connectToSpeechd({ autoSpawn: !autoSpawn });
     const broker = createWebSocket();
 
     await broker.ready;

--- a/services/speech/src/speechd/environment.js
+++ b/services/speech/src/speechd/environment.js
@@ -17,6 +17,7 @@ const getExecutablePath = async () => {
 };
 
 const getSocketPath = () =>
+  process.env.SOCKET_PATH ||
   `${process.env.XDG_RUNTIME_DIR}/speech-dispatcher/speechd.sock`;
 
 module.exports = {

--- a/services/speech/test.html
+++ b/services/speech/test.html
@@ -5,7 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Test speechd-service</title>
-  <script src="http://raspberrypi.local/websocket"></script>
+  <script async src="http://raspberrypi.local/websocket" onload="init()"></script>
+  <script async src="http://localhost:5000/websocket" onload="init()"></script>
 </head>
 
 <body>
@@ -13,45 +14,55 @@
   <button id="speak">Speak!</button>
   <button id="list-voices">List voices</button>
   <script>
-    const ws = createWebsocket({ url: wsUrl() });
+    let loaded = false;
 
-    ws.subscribe(new RegExp('speech/event/.*'), ({ topic, payload }) => console.log(topic, payload));
+    const init = () => {
+      if (loaded) { return; }
 
-    function wsUrl(search = window.location.search) {
-      const params = new URLSearchParams(search);
-      const host = params.get('host') || window.location.hostname;
-      const port = params.get('port') || window.location.port;
+      console.log('Init');
 
-      return `ws://${host}:${port}`;
-    }
+      loaded = true;
 
-    const speak = function () {
-      const utterance = document.querySelector('input').value;
-      ws.publish({ topic: 'speech/command/speak', payload: { utterance } });
-    }
+      const ws = createWebsocket({ url: wsUrl() });
 
-    const listVoices = function () {
-      ws.publish({ topic: 'speech/command/listvoices' });
-    }
+      ws.subscribe(new RegExp('speech/event/.*'), ({ topic, payload }) => console.log(topic, payload));
 
-    document.querySelector('#speak').addEventListener(
-      'click',
-      speak
-    );
+      function wsUrl(search = window.location.search) {
+        const params = new URLSearchParams(search);
+        const host = params.get('host') || window.location.hostname;
+        const port = params.get('port') || window.location.port;
 
-    document.querySelector('input').addEventListener(
-      'keyup',
-      function (evt) {
-        if (evt.keyCode === 13 /* ENTER */) {
-          speak();
-        }
+        return `ws://${host}:${port}`;
       }
-    );
 
-    document.querySelector('#list-voices').addEventListener(
-      'click',
-      listVoices
-    );
+      const speak = function () {
+        const utterance = document.querySelector('input').value;
+        ws.publish({ topic: 'speech/command/speak', payload: { utterance } });
+      }
+
+      const listVoices = function () {
+        ws.publish({ topic: 'speech/command/listvoices' });
+      }
+
+      document.querySelector('#speak').addEventListener(
+        'click',
+        speak
+      );
+
+      document.querySelector('input').addEventListener(
+        'keyup',
+        function (evt) {
+          if (evt.keyCode === 13 /* ENTER */) {
+            speak();
+          }
+        }
+      );
+
+      document.querySelector('#list-voices').addEventListener(
+        'click',
+        listVoices
+      );
+    }
   </script>
 </body>
 


### PR DESCRIPTION
This creates a couple of environment variables so that we can support speech servers other than `speech-dispatcher`.

`NO_AUTO_SPAWN=anything` prevents the `speech` service from trying to automatically the `speech-dispatcher` server.

`SOCKET_PATH` allows the socket that the speech server is running on to be specified.

So, for running this locally:

`SOCKET_PATH=/tmp/speed.sock NO_AUTO_SPAWN=anything node src/main` can be used.