### PR TITLE
Explicitly handle WebSocket errors as this crashes the process on node

### DIFF
--- a/shared/websocket/index.js
+++ b/shared/websocket/index.js
@@ -94,6 +94,10 @@ const createWebsocket = (opts = {}) => {
     setTimeout(connect, 500);
   };
 
+  const onError = (err) => {
+    log('Websocket error', err);
+  };
+
   const subscribe = (topic, cb) => {
     subscriptions.subscribe(topic, cb);
   };
@@ -119,6 +123,7 @@ const createWebsocket = (opts = {}) => {
     ws = new WebSocket(url);
     ws.addEventListener('message', onMessage);
     ws.addEventListener('close', onClose);
+    ws.addEventListener('error', onError);
 
     ready = new Promise(resolve => {
       ws.addEventListener('open', resolve);


### PR DESCRIPTION
On nodejs, if the WebSocket broker is not running and `createWebSocket()` is called, the process crashes with a `ECONNREFUSED` error instead of trying to reconnect. Explicitly handling the `error` event prevents the crash and allows the `close` event handler to do it's reconnection magic.