### PR TITLE
Fix for MacOS Chrome not spawning new browser instance if already running

### DIFF
--- a/services/manager/start-web-environment.sh
+++ b/services/manager/start-web-environment.sh
@@ -10,7 +10,7 @@ if command -v chromium-browser; then
   sleep 5
   chromium-browser --headless $ARGS
 elif [ -f "$MACOS_CHROME" ]; then
-  "$MACOS_CHROME" $ARGS
+  "$MACOS_CHROME" --user-data-dir=/tmp $ARGS
 else
   echo "No chrome"
   exit 1


### PR DESCRIPTION
On MacOS, if Chrome is already running when `start-web-environment.sh` script is executed, the manager page is opened in a new tab of the existing Chrome session, and the script exits immediately. When running in a Procfile with `foreman`, the script exiting causes all the other services to be terminated too.

Adding `--user-data-dir=/tmp` forces Chrome to start a new session separate from the currently running Chrome instance. The start script then doesn't exit, but instead displays logging information and `foreman` continues running all services.