### PR TITLE
Throws ConnectionError if connection fails and no autospawn

### DIFF
--- a/services/speech/src/speechd/connect.js
+++ b/services/speech/src/speechd/connect.js
@@ -10,7 +10,7 @@ const connect = async ({ autoSpawn = true, ...params } = {}) => {
   try {
     connection = await connectToSocket(params);
   } catch (e) {
-    if (e instanceof ConnectionError) {
+    if (e instanceof ConnectionError && autoSpawn) {
       connection = null;
     } else {
       throw e;


### PR DESCRIPTION
If connecting to the speechd server fails and autospawn is not enabled then we should raise the ConnectionError. At the moment, this fails but creates an "unhandled promise rejection" which is SAD.