### PR TITLE
Helpful topic name error

### DIFF
--- a/docs/WEBSOCKETS.md
+++ b/docs/WEBSOCKETS.md
@@ -6,7 +6,7 @@ short set of standards.
 
 ## Topics
 
-There are two forms of topics:
+There are two types of topics:
 
 ### Events
 
@@ -17,11 +17,21 @@ your app or service.
 
 An app or service wishes to make a change in the state of another.
 
-The format of a topic is as follows:
+### Valid topic names
+
+A topic must consist of three parts:
 
 `programme-name/command-or-event/topic-name`
 
-e.g. the topic required to command the `downloader` service to download a link
+`programme-name` and `topic-name` can be lowercase letters, numbers or hyphens but must start with a lowercase letter.
+
+`command-or-event` must be either `command` or `event`.
+
+The three parts of a topic must be separated by `/`.
+
+### Examples
+
+The topic required to command the `downloader` service to download a link
 would be: `downloader/command/request`. Once the file has been downloaded, the
 service would respond with a message on the topic `downloader/event/available`.
 

--- a/shared/websocket/index.js
+++ b/shared/websocket/index.js
@@ -7,9 +7,10 @@ const defaultURL = `ws://${hostname}:8000`;
 const topicRegexp = /^([a-z]+[a-z0-9-]*)\/(command|event)\/([a-z]+[a-z0-9-]*)$/;
 
 class InvalidTopicError extends Error {
-  constructor(topic, topicRegexp) {
+  constructor(topic) {
     super(
-      `"${topic}" is not a valid topic. Topic names must match ${topicRegexp.toString()}`
+      `"${topic}" is not a valid topic. For valid topic names, see the WebSocket guide: https://github.com/andrewn/neue-radio/blob/master/docs/WEBSOCKETS.md.
+`
     );
   }
 }
@@ -19,7 +20,7 @@ const validTopic = topic => {
     return true;
   }
 
-  throw new InvalidTopicError(topic, topicRegexp);
+  throw new InvalidTopicError(topic);
 };
 
 const createSubscriptions = log => {

--- a/shared/websocket/index.js
+++ b/shared/websocket/index.js
@@ -1,10 +1,12 @@
-const WebSocket = (typeof window == 'undefined') ? require('ws') : window.WebSocket;
-const hostname = (typeof window == 'undefined') ? '127.0.0.1' : window.location.hostname;
+const WebSocket =
+  typeof window == "undefined" ? require("ws") : window.WebSocket;
+const hostname =
+  typeof window == "undefined" ? "127.0.0.1" : window.location.hostname;
 
 const defaultURL = `ws://${hostname}:8000`;
 const topicRegexp = /^([a-z]+[a-z0-9-]*)\/(command|event)\/([a-z]+[a-z0-9-]*)$/;
 
-const validTopic = (topic) => {
+const validTopic = topic => {
   if (topicRegexp.test(topic)) {
     return true;
   }
@@ -12,13 +14,12 @@ const validTopic = (topic) => {
   throw new Error(`${topic} is not a valid topic`);
 };
 
-const createSubscriptions = (log) => {
-  const isGroup = obj => (obj instanceof RegExp);
+const createSubscriptions = log => {
+  const isGroup = obj => obj instanceof RegExp;
   const subscriptions = { single: new Map(), group: new Map() };
 
   const set = (map, topic, callback) => {
-    const keys = Array.from(map.keys())
-      .map(k => k.toString());
+    const keys = Array.from(map.keys()).map(k => k.toString());
 
     if (keys.includes(topic.toString())) {
       throw new Error(`Already subscribed to ${topic}`);
@@ -27,10 +28,14 @@ const createSubscriptions = (log) => {
     map.set(topic, callback);
   };
 
-  const matching = (topic) => {
+  const matching = topic => {
     const groupMatches = Array.from(subscriptions.group.entries())
-      .filter(([t, _]) => { return t.test(topic) })
-      .map(([_, callback]) => { return callback });
+      .filter(([t, _]) => {
+        return t.test(topic);
+      })
+      .map(([_, callback]) => {
+        return callback;
+      });
 
     const singleMatch = subscriptions.single.get(topic);
 
@@ -43,7 +48,7 @@ const createSubscriptions = (log) => {
     return groupMatches;
   };
 
-  const unsubscribe = (topic) => {
+  const unsubscribe = topic => {
     log(`Unsubscribing ${topic}`);
 
     if (isGroup(topic)) {
@@ -83,26 +88,26 @@ const createWebsocket = (opts = {}) => {
 
   const subscriptions = createSubscriptions(log);
 
-  const onMessage = (event) => {
+  const onMessage = event => {
     const { topic, payload } = JSON.parse(event.data);
 
     subscriptions.matching(topic).forEach(cb => cb({ topic, payload }));
   };
 
-  const onClose = (err) => {
-    log('Websocket disconnected', err);
+  const onClose = err => {
+    log("Websocket disconnected", err);
     setTimeout(connect, 500);
   };
 
-  const onError = (err) => {
-    log('Websocket error', err);
+  const onError = err => {
+    log("Websocket error", err);
   };
 
   const subscribe = (topic, cb) => {
     subscriptions.subscribe(topic, cb);
   };
 
-  const unsubscribe = (topic) => {
+  const unsubscribe = topic => {
     subscriptions.unsubscribe(topic);
   };
 
@@ -121,13 +126,13 @@ const createWebsocket = (opts = {}) => {
     log(`Connecting to ${url}`);
 
     ws = new WebSocket(url);
-    ws.addEventListener('message', onMessage);
-    ws.addEventListener('close', onClose);
-    ws.addEventListener('error', onError);
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("close", onClose);
+    ws.addEventListener("error", onError);
 
     ready = new Promise(resolve => {
-      ws.addEventListener('open', resolve);
-    }).then(() => (log(`Connected to ${url}`)));
+      ws.addEventListener("open", resolve);
+    }).then(() => log(`Connected to ${url}`));
   };
 
   connect();
@@ -135,7 +140,6 @@ const createWebsocket = (opts = {}) => {
   return { publish, subscribe, unsubscribe, ready };
 };
 
-
 (function(exports) {
   exports.default = createWebsocket;
-})(typeof exports === 'undefined' ? this.share = {} : exports);
+})(typeof exports === "undefined" ? (this.share = {}) : exports);

--- a/shared/websocket/index.js
+++ b/shared/websocket/index.js
@@ -6,12 +6,20 @@ const hostname =
 const defaultURL = `ws://${hostname}:8000`;
 const topicRegexp = /^([a-z]+[a-z0-9-]*)\/(command|event)\/([a-z]+[a-z0-9-]*)$/;
 
+class InvalidTopicError extends Error {
+  constructor(topic, topicRegexp) {
+    super(
+      `"${topic}" is not a valid topic. Topic names must match ${topicRegexp.toString()}`
+    );
+  }
+}
+
 const validTopic = topic => {
   if (topicRegexp.test(topic)) {
     return true;
   }
 
-  throw new Error(`${topic} is not a valid topic`);
+  throw new InvalidTopicError(topic, topicRegexp);
 };
 
 const createSubscriptions = log => {


### PR DESCRIPTION
Most of the noise is prettier formatting, but [this commit](https://github.com/andrewn/neue-radio/commit/4aef7bf2d3c2cdec20b720b2a2096c77b25a382c) includes the valid topic RegExp in the error message to give library users a hint about what's wrong. Not the best, but better? 