### PR TITLE
Update script fails

### DIFF
--- a/deployment/update
+++ b/deployment/update
@@ -32,7 +32,10 @@ const findApplicableDirectories = async rootDir => {
 
 const install = async ({ name, path }) => {
   try {
-    await exec(`npm install --production`, { cwd: path, env: { JOBS: "max" } });
+    await exec(`npm install --production`, {
+      cwd: path,
+      env: { ...process.env, JOBS: "max" }
+    });
     log.ok(`Completed ${name}`);
   } catch (e) {
     log.error(`Error installing/updating: ${name}`);

--- a/deployment/update
+++ b/deployment/update
@@ -36,10 +36,11 @@ const install = async ({ name, path }) => {
       cwd: path,
       env: { ...process.env, JOBS: "max" }
     });
-    log.ok(`Completed ${name}`);
-  } catch (e) {
+    log.ok(`Completed: ${name}`);
+    return { name, error: null };
+  } catch (error) {
     log.error(`Error installing/updating: ${name}`);
-    throw e;
+    return { name, error };
   }
 };
 
@@ -51,12 +52,19 @@ const main = async () => {
 
   const names = toInstall.map(({ name }) => name);
 
-  log.ok(`Update the following: ${names.join(", ")}`);
+  log.ok(`Update the following: ${names.join(", ")}\n`);
 
-  Promise.all(toInstall.map(install)).then(
-    () => process.exit(0),
-    () => process.exit(1)
-  );
+  const results = await Promise.all(toInstall.map(install));
+
+  const failed = results.filter(r => r.error);
+
+  if (failed.length > 0) {
+    log.error(`\n${failed.length} failure${failed.length == 1 ? "" : "s"}.`);
+  } else {
+    log.ok("\nAll updated");
+  }
+
+  process.exit(failed.length);
 };
 
 main();

--- a/deployment/update
+++ b/deployment/update
@@ -20,7 +20,7 @@ const hasPackageDotJson = ({ path }) =>
 
 const pathForName = parent => name => ({ name, path: join(parent, name) });
 
-const findApplicableDirectories = async (rootDir) => {
+const findApplicableDirectories = async rootDir => {
   const fullPath = resolve(join(__dirname, "..", rootDir));
   const paths = (await readdir(fullPath)).map(pathForName(fullPath));
 
@@ -32,10 +32,7 @@ const findApplicableDirectories = async (rootDir) => {
 
 const install = async ({ name, path }) => {
   try {
-    await exec(
-      `npm install --production`,
-      { cwd: path, env: { JOBS: 'max' } }
-    );
+    await exec(`npm install --production`, { cwd: path, env: { JOBS: "max" } });
     log.ok(`Completed ${name}`);
   } catch (e) {
     log.error(`Error installing/updating: ${name}`);
@@ -44,8 +41,8 @@ const install = async ({ name, path }) => {
 };
 
 const main = async () => {
-  const services = await findApplicableDirectories('services');
-  const apps = await findApplicableDirectories('apps');
+  const services = await findApplicableDirectories("services");
+  const apps = await findApplicableDirectories("apps");
 
   const toInstall = [...services, ...apps];
 


### PR DESCRIPTION
Fixes a bug in update script that was causing it to fail on all items. This might be because I'm using `nvm`. Passing through the current processes `env` to each subprocess fixes it.

The script now collects the number of failed installs and displays them rather than exiting at the first failure, which the previous version did.