### PR TITLE
Do not run rfid or physical service initially

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -65,6 +65,7 @@ ln -sf /opt/node/bin/npm /usr/local/bin/npm
 echo "*** Radiodan"
 mkdir -p /opt/radiodan
 mkdir -p /opt/radiodan/processes/services
+touch /opt/radiodan/processes/services/{downloader,speech}
 
 cd /opt/radiodan
 git clone https://github.com/andrewn/neue-radio rde

--- a/deployment/provision
+++ b/deployment/provision
@@ -65,7 +65,6 @@ ln -sf /opt/node/bin/npm /usr/local/bin/npm
 echo "*** Radiodan"
 mkdir -p /opt/radiodan
 mkdir -p /opt/radiodan/processes/services
-touch /opt/radiodan/processes/services/{downloader,rfid,physical}
 
 cd /opt/radiodan
 git clone https://github.com/andrewn/neue-radio rde


### PR DESCRIPTION
On provision, do not run any of the non-core services e.g. `downloader`, `rfid` or `physical` as they can interact in weird ways. They can be easily enabled via the `setup` service when required.