### PR TITLE
Resolve paths when looking for apps to run

### DIFF
--- a/services/manager/index.js
+++ b/services/manager/index.js
@@ -9,10 +9,11 @@ const webSocketPort = process.env.WEBSOCKET_PORT || 8000;
 const internalPort = process.env.INTERNAL_PORT || 5001;
 const externalPort = process.env.EXTERNAL_PORT || 5000;
 
-const appPath = path.resolve(__dirname, '..', '..', 'apps');
+const appPath = path.join('..', '..', 'apps');
 const managerPublicPath = path.join(__dirname, 'public');
 
-const apps = process.env.APP_PATH ? knownApps(process.env.APP_PATH) : findApps(appPath);
+const apps = process.env.APP_PATH ?
+  knownApps(__dirname)(process.env.APP_PATH) : findApps(__dirname)(appPath);
 
 http.mountExternal(apps, externalPort);
 http.mountInternal(apps, internalPort, managerPublicPath);

--- a/services/manager/lib/apps/index.js
+++ b/services/manager/lib/apps/index.js
@@ -4,18 +4,20 @@ const path = require('path');
 const isDirectory = ({ path }) => fs.statSync(path).isDirectory();
 const isNotHiddenDirectory = ({ path }) => path[0] !== '.';
 
-const findApps = source => (
-  fs
-    .readdirSync(source)
-    .map(name => ({ path: path.join(source, name), name }))
+const findApps = rootPath => source => {
+  const fullPath = path.resolve(rootPath, source);
+
+  return fs
+    .readdirSync(fullPath)
+    .map(name => ({ path: path.join(fullPath, name), name }))
     .filter(isDirectory)
     .filter(isNotHiddenDirectory)
-);
+};
 
-const knownApps = appPath => (
+const knownApps = rootPath => appPath => (
   appPath
     .split(':')
-    .map(a => ({ path: a, name: path.posix.basename(a) }))
+    .map(a => ({ path: path.resolve(rootPath, a), name: path.posix.basename(a) }))
     .filter(isDirectory)
     .filter(isNotHiddenDirectory)
 );


### PR DESCRIPTION
This allows you to use relative paths at the command line, e.g.:

`APP_PATH=../apps/app-name npm start`