### PR TITLE
Exit uncleanly when attempting a restart

### DIFF
--- a/services/manager/lib/restart/index.js
+++ b/services/manager/lib/restart/index.js
@@ -1,5 +1,5 @@
 const createWebsocket = require('websocket').default;
-const shutdown = () => process.exit(0);
+const shutdown = () => process.exit(1);
 
 const listenForRestart = () => {
   const ws = createWebsocket();


### PR DESCRIPTION
https://www.freedesktop.org/software/systemd/man/systemd.service.html#id-1.8.3.17.2.3

Our current systemd config for this service has the Restart setting of
`on-failure`. This requires the process to exit with a code other than 0
in order to trigger a restart.