### PR TITLE
Configures pulseaudio in system mode

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -93,6 +93,16 @@ systemctl enable debug
 systemctl enable speech
 systemctl enable setup
 
+cd /opt/radiodan/rde
+echo "*** Pulse Audio system mode"
+adduser pi pulse
+sed -i '/load-module module-native-protocol-unix/c load-module\ module-native-protocol-unix auth-anonymous=1\ socket=/tmp/pulseaudio-system.sock\nload-module module-native-protocol-tcp auth-anonymous=1 auth-ip-acl=127.0.0.1;192.168.178.0/24' /etc/pulse/system.pa
+mkdir -p /home/pi/.config/pulse/
+echo "default-server = unix:/tmp/pulseaudio-system.sock" >> /home/pi/.config/pulse/client.conf
+chown -R pi:pi /home/pi/.config/pulse/
+cp deployment/systemd/pulseaudio.service /etc/systemd/system/
+systemctl enable pulseaudio
+
 echo "*** IPTables (Port forwarding)"
 DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages iptables-persistent
 # All requests to port 80 go to port 5000

--- a/deployment/systemd/pulseaudio.service
+++ b/deployment/systemd/pulseaudio.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=PulseAudio system server
+
+[Service]
+ExecStart=/usr/bin/pulseaudio --system --disallow-exit --log-target=journal --disallow-module-loading --daemonize=no
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This enables pulseaudio as a systemd service that is started on boot.

This mode is [designed for embedded systems][1] that aren't really multi-user. This is a workaround for a bug where two instances of pulseaudio are starting for the Pi user causing problems such as not being able to mute or set the sound level.

[1]: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/