### PR TITLE
Provisioning QOL Improvement

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -69,17 +69,8 @@ touch /opt/radiodan/processes/services/{downloader,speech}
 
 cd /opt/radiodan
 git clone https://github.com/andrewn/neue-radio rde
-cd rde/shared/websocket
-npm install --production
-cd ../..
 
-for f in apps/* services/*; do
-   if [ -d ${f} ]; then
-      cd $f
-      JOBS=max npm install --unsafe-perm --production
-      cd -
-   fi
-done
+/opt/radiodan/rde/deployment/update
 
 chown -R pi:pi /opt/radiodan
 cp deployment/systemd/*.service /etc/systemd/system/

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,7 +51,7 @@ Connect an Ethernet cable or set-up wifi. Power as normal via it's power input.
 
 ## Steps for all Pis
 
-Run the `deployment/provision` script from the command line.
+    curl https://raw.githubusercontent.com/andrewn/neue-radio/master/deployment/provision | sudo bash
 
 ## Install pHat DAC if using
 


### PR DESCRIPTION
- Use update script to install all npm dependencies
- Add one-liner provisioning step for the Pi 

Fixes #83
