### PR TITLE
Re-request IP address if one has not been set

### DIFF
--- a/services/debug/index.js
+++ b/services/debug/index.js
@@ -1,11 +1,9 @@
-const ip = require('ip');
-
 const server = require('./lib/server');
 const debuggers = require('./lib/debuggers');
 
 const main = () => {
   const port = process.env.PORT || 5005;
-  const debuggerHost = process.env.REMOTE_DEBUGGER_HOST || ip.address();
+  const debuggerHost = process.env.REMOTE_DEBUGGER_HOST;
   const debuggerPort = process.env.REMOTE_DEBUGGER_PORT || 9222;
 
   console.log(`Remote debugger: ${debuggerHost}:${debuggerPort}`);

--- a/services/debug/lib/debuggers.js
+++ b/services/debug/lib/debuggers.js
@@ -1,17 +1,21 @@
+const ip = require('ip');
 const http = require('http');
 const assert = require('assert');
 
-const get = ({ debuggerHost, debuggerPort }) => {
-  assert(debuggerHost, 'debuggerHost required');
+const getDeviceListUrl = (defaultIp, defaultPort) => (currentIp) => (
+  `http://${defaultIp || currentIp}:${defaultPort}/json/list`
+);
+
+const get = ({ debuggerHost = false, debuggerPort }) => {
   assert(debuggerPort, 'debuggerPort required');
 
-  const deviceListUrl = `http://${debuggerHost}:${debuggerPort}/json/list`;
+  const deviceListUrl = getDeviceListUrl(debuggerHost, debuggerPort);
 
   return () =>
     new Promise((resolve, reject) => {
       // Fetch a list of pages on the remote chrome instance
       http
-        .get(deviceListUrl, res => {
+        .get(deviceListUrl(ip.address()), res => {
           res.setEncoding('utf8');
           let rawData = '';
           res.on('data', chunk => {


### PR DESCRIPTION
A device's IP address is fluid. So, in order to always have the correct
address, the debbuger re-requests it on each page load.

If an IP has been set by environment variable, the address will not
change.

Fixes #84