### PR TITLE
Formats all code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/apps/youtube/src/external.js
+++ b/apps/youtube/src/external.js
@@ -10,11 +10,11 @@ const createComms = async handler => {
     requestStop: () => send('stop')
   };
 
-  ws.subscribe(new RegExp('youtube/event/.*'), (msg) => {
+  ws.subscribe(new RegExp('youtube/event/.*'), msg => {
     handler(msg);
   });
 
-  return ws.ready.then(() => (instance));
+  return ws.ready.then(() => instance);
 };
 
 const setState = id => {

--- a/apps/youtube/src/internal.js
+++ b/apps/youtube/src/internal.js
@@ -25,7 +25,7 @@ const createComms = async handler => {
   ws.subscribe(new RegExp('youtube/command/.*'), handler);
   ws.subscribe('downloader/event/available', handler);
 
-  return ws.ready.then(() => (instance));
+  return ws.ready.then(() => instance);
 };
 
 const playMedia = url => {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "neue-radio",
   "version": "0.1.0",
-  "description": "Experiment for a new radio prototyping kit for the next radiodan.",
+  "description":
+    "Experiment for a new radio prototyping kit for the next radiodan.",
   "main": "index.js",
   "scripts": {
-    "start": "nf start --procfile ./deployment/Procfile --env ./deployment/systemd/ports.env",
+    "start":
+      "nf start --procfile ./deployment/Procfile --env ./deployment/systemd/ports.env",
     "create-app": "node ./shared/create-new-app/index.js",
     "lint": "eslint **/*.js",
     "install-all": "./deployment/update",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format-code": "prettier --write '{apps,services,shared}/**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/services/debug/lib/debuggers.js
+++ b/services/debug/lib/debuggers.js
@@ -2,9 +2,8 @@ const ip = require('ip');
 const http = require('http');
 const assert = require('assert');
 
-const getDeviceListUrl = (defaultIp, defaultPort) => (currentIp) => (
-  `http://${defaultIp || currentIp}:${defaultPort}/json/list`
-);
+const getDeviceListUrl = (defaultIp, defaultPort) => currentIp =>
+  `http://${defaultIp || currentIp}:${defaultPort}/json/list`;
 
 const get = ({ debuggerHost = false, debuggerPort }) => {
   assert(debuggerPort, 'debuggerPort required');

--- a/services/downloader/index.js
+++ b/services/downloader/index.js
@@ -16,13 +16,16 @@ const downloader = createDownloader(downloadPath);
 http({ port, publicPath: downloadPath });
 ws({ host, downloader });
 
-if(process.env.DEBUG) {
+if (process.env.DEBUG) {
   setTimeout(() => {
     logger.info('Sending demo message');
 
     const WebSocket = require('ws');
     const ws = new WebSocket('ws://' + host.host + ':8000');
-    const msg = JSON.stringify({topic: 'mediaRequest', payload: { url: 'https://www.youtube.com/watch?v=0bYY8m1Lb2I' }});
+    const msg = JSON.stringify({
+      topic: 'mediaRequest',
+      payload: { url: 'https://www.youtube.com/watch?v=0bYY8m1Lb2I' }
+    });
 
     ws.on('open', () => ws.send(msg));
   }, 1000);

--- a/services/downloader/lib/downloader/async-exec/index.js
+++ b/services/downloader/lib/downloader/async-exec/index.js
@@ -1,7 +1,7 @@
 const { exec } = require('child_process');
 
-const asyncExec = cmd => (
-  new Promise((resolve, reject) => (
+const asyncExec = cmd =>
+  new Promise((resolve, reject) =>
     exec(cmd, (error, stdout, stderr) => {
       if (error) {
         return reject(error);
@@ -9,7 +9,6 @@ const asyncExec = cmd => (
 
       resolve(stdout);
     })
-  ))
-);
+  );
 
 module.exports = asyncExec;

--- a/services/downloader/lib/downloader/index.js
+++ b/services/downloader/lib/downloader/index.js
@@ -21,10 +21,8 @@ const command = (downloadPath, url) => {
 };
 
 const parsedOutputPath = (downloadPath, output) => {
-  const videoPath = path.join(downloadPath, '([0-9a-z_\\-\\\/\.]+)');
-  const match = output.match(
-    new RegExp(`\[download\].*${videoPath}.*`, 'i')
-  );
+  const videoPath = path.join(downloadPath, '([0-9a-z_\\-\\/.]+)');
+  const match = output.match(new RegExp(`\[download\].*${videoPath}.*`, 'i'));
 
   logger.info(`Downloaded to ${match[1]}`);
   return match[1];

--- a/services/downloader/lib/io/http/index.js
+++ b/services/downloader/lib/io/http/index.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const serveIndex = require('serve-index')
+const serveIndex = require('serve-index');
 
 const logger = require('../../logger')('http');
 
@@ -7,13 +7,9 @@ const web = ({ port, publicPath }) => {
   const app = express();
   const serveStatic = express.static(publicPath);
 
-  app.use(serveStatic)
+  app.use(serveStatic);
 
-  app.use(
-    '/videos',
-    serveIndex(publicPath, {'icons': true}),
-    serveStatic,
-  );
+  app.use('/videos', serveIndex(publicPath, { icons: true }), serveStatic);
 
   app.get('/', (req, res) => {
     res.send('Video Download Service');

--- a/services/downloader/lib/io/ws/index.js
+++ b/services/downloader/lib/io/ws/index.js
@@ -14,19 +14,17 @@ const webSocket = ({ host, downloader }) => {
   ws.subscribe(subscribedTopic, handler);
 };
 
-const sendMessage = ws => (topic, payload) => (
-  ws.publish({ topic, payload })
-);
+const sendMessage = ws => (topic, payload) => ws.publish({ topic, payload });
 
-const handleMessage = ({ host, downloader, callback }) => async ({ payload }) => {
+const handleMessage = ({ host, downloader, callback }) => async ({
+  payload
+}) => {
   const { url: sourceUrl } = payload;
 
   const videoPath = await downloader(sourceUrl);
   const url = new URL(videoPath, host);
 
-  callback(
-    publishTopic, { url, sourceUrl }
-  );
+  callback(publishTopic, { url, sourceUrl });
 };
 
 module.exports = webSocket;

--- a/services/downloader/lib/logger/index.js
+++ b/services/downloader/lib/logger/index.js
@@ -1,16 +1,15 @@
 const { createLogger, format, transports } = require('winston');
 const { combine, timestamp, label, printf } = format;
 
-const myFormat = defaultLabel => printf(info => {
-  return `${info.timestamp} [${info.label || defaultLabel}] ${info.level}: ${info.message}`;
-});
+const myFormat = defaultLabel =>
+  printf(info => {
+    return `${info.timestamp} [${info.label || defaultLabel}] ${info.level}: ${
+      info.message
+    }`;
+  });
 
-module.exports = (label) => (
+module.exports = label =>
   createLogger({
-    format: combine(
-      timestamp(),
-      myFormat(label)
-    ),
+    format: combine(timestamp(), myFormat(label)),
     transports: [new transports.Console()]
-  })
-);
+  });

--- a/services/manager/index.js
+++ b/services/manager/index.js
@@ -12,8 +12,9 @@ const externalPort = process.env.EXTERNAL_PORT || 5000;
 const appPath = path.join('..', '..', 'apps');
 const managerPublicPath = path.join(__dirname, 'public');
 
-const apps = process.env.APP_PATH ?
-  knownApps(__dirname)(process.env.APP_PATH) : findApps(__dirname)(appPath);
+const apps = process.env.APP_PATH
+  ? knownApps(__dirname)(process.env.APP_PATH)
+  : findApps(__dirname)(appPath);
 
 http.mountExternal(apps, externalPort);
 http.mountInternal(apps, internalPort, managerPublicPath);

--- a/services/manager/lib/apps/index.js
+++ b/services/manager/lib/apps/index.js
@@ -11,16 +11,18 @@ const findApps = rootPath => source => {
     .readdirSync(fullPath)
     .map(name => ({ path: path.join(fullPath, name), name }))
     .filter(isDirectory)
-    .filter(isNotHiddenDirectory)
+    .filter(isNotHiddenDirectory);
 };
 
-const knownApps = rootPath => appPath => (
+const knownApps = rootPath => appPath =>
   appPath
     .split(':')
-    .map(a => ({ path: path.resolve(rootPath, a), name: path.posix.basename(a) }))
+    .map(a => ({
+      path: path.resolve(rootPath, a),
+      name: path.posix.basename(a)
+    }))
     .filter(isDirectory)
-    .filter(isNotHiddenDirectory)
-);
+    .filter(isNotHiddenDirectory);
 
 module.exports.findApps = findApps;
 module.exports.knownApps = knownApps;

--- a/services/manager/lib/io/http/index.js
+++ b/services/manager/lib/io/http/index.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const ip = require('ip');
 const pathLib = require('path');
-const serveIndex = require('serve-index')
+const serveIndex = require('serve-index');
 
 const logger = require('../logger');
 
 const directoryListing = ({ fileList, directory }, callback) => {
   const listing = fileList
-    .filter(({ name }) => (name[0] != '.'))
-    .map(({ name }) => (directory + name));
+    .filter(({ name }) => name[0] != '.')
+    .map(({ name }) => directory + name);
 
   callback(false, JSON.stringify(listing));
 };
@@ -23,16 +23,18 @@ const mountApp = ({ server, name, path, index }) => {
   server.use(pathLib.join(httpPath, 'modules'), serveModules);
 
   const serveAssets = express.static(pathLib.join(path, 'assets'));
-  const listAssets = serveIndex(pathLib.join(path, 'assets'), { template: directoryListing });
+  const listAssets = serveIndex(pathLib.join(path, 'assets'), {
+    template: directoryListing
+  });
   server.use(pathLib.join(httpPath, 'assets'), serveAssets, listAssets);
 };
 
 const mountAppList = (apps, server) => {
-  const appNames = apps.map( a => a.name );
+  const appNames = apps.map(a => a.name);
 
   server.get('/apps', (req, res) =>
     res.json({
-      apps: appNames,
+      apps: appNames
     })
   );
 
@@ -40,9 +42,9 @@ const mountAppList = (apps, server) => {
 };
 
 const startServer = (server, port, name) => {
-  server.listen(port, () => (
+  server.listen(port, () =>
     logger.log('http', `${name} Server http://${ip.address()}:${port}`)
-  ));
+  );
 };
 
 const mountWebsocket = server => {
@@ -51,10 +53,7 @@ const mountWebsocket = server => {
   const mountAt = '/websocket';
   const index = 'index.js';
 
-  const serveStatic = express.static(
-    path,
-    { index }
-  );
+  const serveStatic = express.static(path, { index });
 
   server.use(mountAt, serveStatic);
 };
@@ -63,7 +62,7 @@ const mountExternal = (apps, port) => {
   const server = express();
 
   apps.map(({ name, path }) => {
-    mountApp({ server, name, path, index: 'external.html' })
+    mountApp({ server, name, path, index: 'external.html' });
   });
 
   mountWebsocket(server);
@@ -76,15 +75,13 @@ const mountInternal = (apps, port, publicPath) => {
 
   mountAppList(apps, server);
 
-  apps.map(({ name, path }) => (
+  apps.map(({ name, path }) =>
     mountApp({ server, name, path, index: 'internal.html' })
-  ));
+  );
 
   mountWebsocket(server);
 
-  server.use(
-    express.static(publicPath)
-  );
+  server.use(express.static(publicPath));
 
   startServer(server, port, 'Private');
 };

--- a/services/manager/lib/io/logger/index.js
+++ b/services/manager/lib/io/logger/index.js
@@ -1,15 +1,16 @@
 const chalk = require('chalk');
 
-const levelColour = (level = 'log') => ({
-  log: chalk.green,
-}[level]);
+const levelColour = (level = 'log') =>
+  ({
+    log: chalk.green
+  }[level]);
 
 const log = (level, prefix, message, ...params) => {
   const formattedPrefix = `[${levelColour(level)(prefix)}]`;
   console.log(formattedPrefix, message, ...params);
-}
+};
 
-const create = (level) => (prefix, message, ...params) => {
+const create = level => (prefix, message, ...params) => {
   if (message == null) {
     return log.bind(null, level, prefix);
   }
@@ -19,5 +20,5 @@ const create = (level) => (prefix, message, ...params) => {
 
 module.exports = {
   bold: chalk.bold,
-  log: create('log'),
+  log: create('log')
 };

--- a/services/manager/lib/io/ws/index.js
+++ b/services/manager/lib/io/ws/index.js
@@ -12,7 +12,10 @@ const createWebsocket = port => {
   webSocketServer.on('connection', function connection(ws) {
     ws.on('message', function incoming(message) {
       logger.log('ws', `Received: ${message}`);
-      logger.log('ws', `Sending to ${logger.bold(webSocketServer.clients.length)} clients`);
+      logger.log(
+        'ws',
+        `Sending to ${logger.bold(webSocketServer.clients.length)} clients`
+      );
 
       webSocketServer.clients.forEach(function each(client) {
         client.send(message);
@@ -20,9 +23,9 @@ const createWebsocket = port => {
     });
   });
 
-  httpServer.listen(port, () => (
+  httpServer.listen(port, () =>
     logger.log('ws', `WebSockets Server http://${ip.address()}:${port}`)
-  ));
+  );
 };
 
 module.exports = createWebsocket;

--- a/services/physical/lib/echo-io.js
+++ b/services/physical/lib/echo-io.js
@@ -3,283 +3,121 @@ var BoardIO = require('board-io');
 
 var pins = {
   0: {
-    pins: [
-      'GPIO17',
-      'P1-11'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO17', 'P1-11'],
+    peripherals: ['gpio']
   },
   1: {
-    pins: [
-      'GPIO18',
-      'PWM0',
-      'P1-12'
-    ],
-    peripherals: [
-      'gpio',
-      'pwm'
-    ]
+    pins: ['GPIO18', 'PWM0', 'P1-12'],
+    peripherals: ['gpio', 'pwm']
   },
   2: {
-    pins: [
-      'GPIO27',
-      'P1-13'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO27', 'P1-13'],
+    peripherals: ['gpio']
   },
   3: {
-    pins: [
-      'GPIO22',
-      'P1-15'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO22', 'P1-15'],
+    peripherals: ['gpio']
   },
   4: {
-    pins: [
-      'GPIO23',
-      'P1-16'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO23', 'P1-16'],
+    peripherals: ['gpio']
   },
   5: {
-    pins: [
-      'GPIO24',
-      'P1-18'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO24', 'P1-18'],
+    peripherals: ['gpio']
   },
   6: {
-    pins: [
-      'GPIO25',
-      'P1-22'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO25', 'P1-22'],
+    peripherals: ['gpio']
   },
   7: {
-    pins: [
-      'GPIO4',
-      'P1-7'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO4', 'P1-7'],
+    peripherals: ['gpio']
   },
   8: {
-    pins: [
-      'GPIO2',
-      'SDA0',
-      'P1-3'
-    ],
-    peripherals: [
-      'gpio',
-      'i2c'
-    ]
+    pins: ['GPIO2', 'SDA0', 'P1-3'],
+    peripherals: ['gpio', 'i2c']
   },
   9: {
-    pins: [
-      'GPIO3',
-      'SCL0',
-      'P1-5'
-    ],
-    peripherals: [
-      'gpio',
-      'i2c'
-    ]
+    pins: ['GPIO3', 'SCL0', 'P1-5'],
+    peripherals: ['gpio', 'i2c']
   },
   10: {
-    pins: [
-      'GPIO8',
-      'CE0',
-      'P1-24'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO8', 'CE0', 'P1-24'],
+    peripherals: ['gpio', 'spi']
   },
   11: {
-    pins: [
-      'GPIO7',
-      'CE1',
-      'P1-26'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO7', 'CE1', 'P1-26'],
+    peripherals: ['gpio', 'spi']
   },
   12: {
-    pins: [
-      'GPIO10',
-      'MOSI0',
-      'P1-19'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO10', 'MOSI0', 'P1-19'],
+    peripherals: ['gpio', 'spi']
   },
   13: {
-    pins: [
-      'GPIO9',
-      'MISO0',
-      'P1-21'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO9', 'MISO0', 'P1-21'],
+    peripherals: ['gpio', 'spi']
   },
   14: {
-    pins: [
-      'GPIO11',
-      'SCLK0',
-      'P1-23'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO11', 'SCLK0', 'P1-23'],
+    peripherals: ['gpio', 'spi']
   },
   15: {
-    pins: [
-      'GPIO14',
-      'TXD0',
-      'P1-8'
-    ],
-    peripherals: [
-      'gpio',
-      'uart'
-    ]
+    pins: ['GPIO14', 'TXD0', 'P1-8'],
+    peripherals: ['gpio', 'uart']
   },
   16: {
-    pins: [
-      'GPIO15',
-      'RXD0',
-      'P1-10'
-    ],
-    peripherals: [
-      'gpio',
-      'uart'
-    ]
+    pins: ['GPIO15', 'RXD0', 'P1-10'],
+    peripherals: ['gpio', 'uart']
   },
   21: {
-    pins: [
-      'GPIO5',
-      'P1-29'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO5', 'P1-29'],
+    peripherals: ['gpio']
   },
   22: {
-    pins: [
-      'GPIO6',
-      'P1-31'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO6', 'P1-31'],
+    peripherals: ['gpio']
   },
   23: {
-    pins: [
-      'GPIO13',
-      'P1-33',
-      'PWM1'
-    ],
-    peripherals: [
-      'gpio',
-      'pwm'
-    ]
+    pins: ['GPIO13', 'P1-33', 'PWM1'],
+    peripherals: ['gpio', 'pwm']
   },
   24: {
-    pins: [
-      'GPIO19',
-      'PWM1',
-      'MISO1',
-      'P1-35'
-    ],
-    peripherals: [
-      'gpio',
-      'pwm',
-      'spi'
-    ]
+    pins: ['GPIO19', 'PWM1', 'MISO1', 'P1-35'],
+    peripherals: ['gpio', 'pwm', 'spi']
   },
   25: {
-    pins: [
-      'GPIO26',
-      'P1-37'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO26', 'P1-37'],
+    peripherals: ['gpio']
   },
   26: {
-    pins: [
-      'GPIO12',
-      'PWM0',
-      'P1-32'
-    ],
-    peripherals: [
-      'gpio',
-      'pwm'
-    ]
+    pins: ['GPIO12', 'PWM0', 'P1-32'],
+    peripherals: ['gpio', 'pwm']
   },
   27: {
-    pins: [
-      'GPIO16',
-      'P1-36'
-    ],
-    peripherals: [
-      'gpio'
-    ]
+    pins: ['GPIO16', 'P1-36'],
+    peripherals: ['gpio']
   },
   28: {
-    pins: [
-      'GPIO20',
-      'MOSI1',
-      'P1-38'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO20', 'MOSI1', 'P1-38'],
+    peripherals: ['gpio', 'spi']
   },
   29: {
-    pins: [
-      'GPIO21',
-      'SCLK1',
-      'P1-40'
-    ],
-    peripherals: [
-      'gpio',
-      'spi'
-    ]
+    pins: ['GPIO21', 'SCLK1', 'P1-40'],
+    peripherals: ['gpio', 'spi']
   }
 };
 
 function mapPins(pins) {
-  return Object.keys(pins).map(function (num) {
+  return Object.keys(pins).map(function(num) {
     return {
       supportedModes: [0, 1, 3, 4],
       mode: 0,
       value: 0,
       report: 1,
-      analogChannel: 127,
+      analogChannel: 127
     };
-  })
+  });
 }
 
 function EchoIO() {
@@ -291,14 +129,15 @@ function EchoIO() {
 
   // wait for an async method or use proccess.nextTick to
   // signal events
-  process.nextTick(function() {
-    // connect to hardware and emit "connect" event
-    this.emit('connect');
+  process.nextTick(
+    function() {
+      // connect to hardware and emit "connect" event
+      this.emit('connect');
 
-    // all done, emit ready event
-    this.emit('ready');
-
-  }.bind(this));
+      // all done, emit ready event
+      this.emit('ready');
+    }.bind(this)
+  );
 }
 util.inherits(EchoIO, BoardIO);
 

--- a/services/physical/lib/http-server.js
+++ b/services/physical/lib/http-server.js
@@ -5,20 +5,20 @@ const path = require('path');
 const filePath = path.join(__dirname, '..', 'test.html');
 
 // Allows requests from other ports
-const allowCors = function(req,res){
+const allowCors = function(req, res) {
   // Set CORS headers
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Request-Method', '*');
   res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
   res.setHeader('Access-Control-Allow-Headers', '*');
-  if ( req.method === 'OPTIONS' ) {
+  if (req.method === 'OPTIONS') {
     res.writeHead(200);
     res.end();
     return;
   }
 
   // Serve the test page
-  readFile(filePath, function (err, contents) {
+  readFile(filePath, function(err, contents) {
     res.write(contents);
     res.end();
   });
@@ -26,4 +26,4 @@ const allowCors = function(req,res){
 
 module.exports.create = function() {
   return http.createServer(allowCors);
-}
+};

--- a/services/physical/lib/physical.js
+++ b/services/physical/lib/physical.js
@@ -1,23 +1,23 @@
-var five = require("johnny-five");
-var pigpio = require("pigpio");
-var EchoIO = require("./echo-io");
+var five = require('johnny-five');
+var pigpio = require('pigpio');
+var EchoIO = require('./echo-io');
 
 var IO = null;
 var RotaryEncoder;
 var connectRaspiCap;
 
 try {
-  IO = require("raspi-io");
+  IO = require('raspi-io');
 } catch (err) {
-  console.error("Raspi-io not found, falling back to EchoIO");
+  console.error('Raspi-io not found, falling back to EchoIO');
   console.error(err);
   IO = EchoIO;
 }
 
 try {
-  RotaryEncoder = require("raspi-rotary-encoder").RotaryEncoder;
+  RotaryEncoder = require('raspi-rotary-encoder').RotaryEncoder;
 } catch (err) {
-  console.error("raspi-rotary-encoder not found, falling back to mock");
+  console.error('raspi-rotary-encoder not found, falling back to mock');
   console.error(err);
   RotaryEncoder = function() {
     return {
@@ -27,9 +27,9 @@ try {
 }
 
 try {
-  connectRaspiCap = require("raspi-cap").connect;
+  connectRaspiCap = require('raspi-cap').connect;
 } catch (err) {
-  console.error("raspi-cap not found, falling back to mock");
+  console.error('raspi-cap not found, falling back to mock');
   console.error(err);
   connectRaspiCap = function() {
     return new Promise.resolve({ on: () => {} });
@@ -76,7 +76,7 @@ module.exports.create = function(router, uiConfig) {
 
   var factories = {
     Button: createButtonInstance,
-    "Led.RGB": createLedRGBInstance,
+    'Led.RGB': createLedRGBInstance,
     Encoder: createEncoderInstance,
     Capacitive: createCapInstance
   };
@@ -88,8 +88,8 @@ module.exports.create = function(router, uiConfig) {
     instances[type] = {};
   });
 
-  board.on("ready", function() {
-    console.log("Board is ready");
+  board.on('ready', function() {
+    console.log('Board is ready');
 
     eachItem(uiConfig, (type, spec) => {
       const factory = factories[type];
@@ -98,7 +98,7 @@ module.exports.create = function(router, uiConfig) {
         const routable = router.register(type, spec.id);
         instances[type][spec.id] = factory(spec, routable);
       } else {
-        console.error("No config or factory for component type: ", type);
+        console.error('No config or factory for component type: ', type);
       }
     });
 
@@ -114,19 +114,19 @@ function createButtonInstance(spec, routable) {
   // const topicKey = 'event.button.' + id;
   const button = new five.Button(Object.assign({ id: id }, config));
 
-  button.on("press", function() {
-    console.log(id + ": Button pressed");
-    routable.publish("press", { pressed: true });
+  button.on('press', function() {
+    console.log(id + ': Button pressed');
+    routable.publish('press', { pressed: true });
   });
 
-  button.on("hold", function() {
-    console.log(id + ": Button held");
-    routable.publish("hold", { pressed: true, durationMs: button.holdtime });
+  button.on('hold', function() {
+    console.log(id + ': Button held');
+    routable.publish('hold', { pressed: true, durationMs: button.holdtime });
   });
 
-  button.on("release", function() {
-    console.log(id + ": Button released");
-    routable.publish("release", { pressed: false });
+  button.on('release', function() {
+    console.log(id + ': Button released');
+    routable.publish('release', { pressed: false });
   });
 
   return button;
@@ -149,10 +149,10 @@ function createLedRGBInstance(spec, routable) {
   //
   // worker.ready();
 
-  routable.on("request", function(req) {
+  routable.on('request', function(req) {
     var stateChangePromise;
 
-    console.log("RGBLED request", req);
+    console.log('RGBLED request', req);
 
     switch (req.command) {
       // case 'change':
@@ -165,7 +165,7 @@ function createLedRGBInstance(spec, routable) {
       //     })
       //   );
       //   break;
-      case "status":
+      case 'status':
         stateChangePromise = Promise.resolve({ color: rgb.color() });
         break;
       default:
@@ -195,15 +195,15 @@ function createEncoderInstance(spec, routable) {
   const encoder = new RotaryEncoder(Object.assign({ id: id }, config));
 
   // the encoder will try to work out where in the loop you are
-  encoder.on("change", function(evt) {
-    routable.publish("turn", evt);
+  encoder.on('change', function(evt) {
+    routable.publish('turn', evt);
   });
 }
 
 function createCapInstance(spec, routable) {
   connectRaspiCap({ resetPin: spec.config.resetPin }).then(cap => {
     // Listen for messages from clients
-    routable.on("resetRequest", function() {
+    routable.on('resetRequest', function() {
       try {
         cap.reset();
       } catch (e) {
@@ -211,25 +211,25 @@ function createCapInstance(spec, routable) {
       }
     });
 
-    routable.on("statusRequest", function() {
-      routable.publish("status", { sensitivty: cap.getSensitivity() });
+    routable.on('statusRequest', function() {
+      routable.publish('status', { sensitivty: cap.getSensitivity() });
     });
 
-    routable.on("sensitivity", function(req) {
+    routable.on('sensitivity', function(req) {
       try {
         cap.setSensitivity(req.params.level);
-        routable.publish("status", { sensitivty: cap.getSensitivity() });
+        routable.publish('status', { sensitivty: cap.getSensitivity() });
       } catch (e) {
         console.error(e);
       }
     });
 
-    cap.on("reset", function() {
-      routable.publish("reset", {});
+    cap.on('reset', function() {
+      routable.publish('reset', {});
     });
 
-    cap.on("change", function(evt) {
-      routable.publish("change", evt);
+    cap.on('change', function(evt) {
+      routable.publish('change', evt);
     });
   });
 }

--- a/services/physical/lib/router.js
+++ b/services/physical/lib/router.js
@@ -3,13 +3,13 @@ const util = require('util');
 
 const SEP = '/';
 
-const Router = function () {
+const Router = function() {
   this.types = {};
 };
 
 util.inherits(Router, EventEmitter);
 
-Router.prototype.register = function (type, id) {
+Router.prototype.register = function(type, id) {
   const self = this;
 
   if (this.types[type] == null) {
@@ -21,7 +21,7 @@ Router.prototype.register = function (type, id) {
   }
 
   const routable = new EventEmitter();
-  routable.publish = function (topic, payload) {
+  routable.publish = function(topic, payload) {
     const path = type + SEP + id + SEP + topic;
     self.emit('publish', { topic: path, payload });
   };
@@ -35,7 +35,7 @@ Router.prototype.register = function (type, id) {
 
 // Takes a routing key of `<type>.<id>.<event>`
 // and fires the correct event on the routable
-Router.prototype.route = function (path, data) {
+Router.prototype.route = function(path, data) {
   const parts = path.split(SEP);
   const type = parts[0];
   const id = parts[1];
@@ -49,15 +49,16 @@ Router.prototype.route = function (path, data) {
 };
 
 // Returns the currently registered types
-Router.prototype.registered = function () {
+Router.prototype.registered = function() {
   const registered = {};
 
-  Object.keys(this.types).forEach(function (type) {
-    registered[type] = Object.keys(this.types[type]);
-  }.bind(this));
+  Object.keys(this.types).forEach(
+    function(type) {
+      registered[type] = Object.keys(this.types[type]);
+    }.bind(this)
+  );
 
   return registered;
-}
-
+};
 
 module.exports = Router;

--- a/services/physical/lib/ws-server.js
+++ b/services/physical/lib/ws-server.js
@@ -10,16 +10,18 @@ module.exports.create = function(server, router) {
 
       // connections.push(ws);
 
-      const handlePublish = function (evt) {
+      const handlePublish = function(evt) {
         ws.send(JSON.stringify(evt));
       };
 
       // On connection, send the currently registered
       // devices
-      ws.send(JSON.stringify({
-        key: 'physical/registered',
-        data: router.registered()
-      }));
+      ws.send(
+        JSON.stringify({
+          key: 'physical/registered',
+          data: router.registered()
+        })
+      );
 
       // We expect incoming messages to have the shape:
       // {

--- a/services/physical/lib/ws.js
+++ b/services/physical/lib/ws.js
@@ -1,6 +1,6 @@
 const createWebsocket = require('websocket').default;
 
-const webSocket = (router) => {
+const webSocket = router => {
   const ws = createWebsocket();
 
   ws.ready.then(() => console.info('Listening to web socket'));
@@ -9,9 +9,9 @@ const webSocket = (router) => {
     router.route(topic, payload);
   });
 
-  router.on('publish', ws => ({ topic, payload }) => (
+  router.on('publish', ws => ({ topic, payload }) =>
     ws.publish({ topic, payload })
-  ));
+  );
 };
 
 module.exports.create = webSocket;

--- a/services/setup/index.js
+++ b/services/setup/index.js
@@ -12,31 +12,29 @@ const app = async () => {
   const appsRoot = resolveRelative('../../apps');
 
   const appsList = await pathsList({
-    rootPath: appsRoot,
+    rootPath: appsRoot
   });
 
   const servicesList = await pathsList({
     rootPath: resolveRelative('..'),
-    ignore: ['manager', 'setup', 'debug'],
+    ignore: ['manager', 'setup', 'debug']
   });
 
-  const appsPath = resolveRelative(
-    process.env.APPS_PATH || './tmp/apps',
-  );
+  const appsPath = resolveRelative(process.env.APPS_PATH || './tmp/apps');
 
   const servicesPath = resolveRelative(
-    process.env.SERVICES_PATH || './tmp/services',
+    process.env.SERVICES_PATH || './tmp/services'
   );
 
   const apps = createApps({
     path: appsPath,
     rootPath: appsRoot,
-    available: appsList,
+    available: appsList
   });
 
   const services = createServices({
     path: servicesPath,
-    available: servicesList,
+    available: servicesList
   });
 
   http({ port, apps, services, installer });

--- a/services/setup/lib/apps/index.js
+++ b/services/setup/lib/apps/index.js
@@ -13,7 +13,7 @@ const apps = ({ path, rootPath, available, alwaysMount = [] }) => {
         .replace(pathEnv, '')
         .split(':')
         .map(a => basename(a));
-    } catch(err) {
+    } catch (err) {
       console.warn('File not found', err);
       return [];
     }
@@ -24,12 +24,12 @@ const apps = ({ path, rootPath, available, alwaysMount = [] }) => {
 
     return available.map(a => ({
       name: a,
-      active: active.includes(a),
-    }))
+      active: active.includes(a)
+    }));
   };
 
-  const set = async (apps=[]) => {
-    if(apps.length == 0) {
+  const set = async (apps = []) => {
+    if (apps.length == 0) {
       return await writeFile(path, '');
     }
 

--- a/services/setup/lib/fs/index.js
+++ b/services/setup/lib/fs/index.js
@@ -12,5 +12,5 @@ module.exports = {
   readDir,
   readFile,
   unlink,
-  writeFile,
+  writeFile
 };

--- a/services/setup/lib/http/index.js
+++ b/services/setup/lib/http/index.js
@@ -2,7 +2,7 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const path = require('path');
 
-const mountWebsocket = (app) => {
+const mountWebsocket = app => {
   const wsPath = path.dirname(require.resolve('websocket'));
   const serveStatic = express.static(wsPath, { index: 'index.js' });
 
@@ -42,9 +42,8 @@ const http = ({ port, apps, services, installer }) => {
     res.json(installText);
   });
 
-  app.listen(
-    port,
-    () => console.log(`Radiodan setup app listening on port ${port}!`)
+  app.listen(port, () =>
+    console.log(`Radiodan setup app listening on port ${port}!`)
   );
 };
 

--- a/services/setup/lib/installer/index.js
+++ b/services/setup/lib/installer/index.js
@@ -1,4 +1,4 @@
-const exec = require("child_process").exec;
+const exec = require('child_process').exec;
 const path = require('path');
 
 const updateBinaryPath = path.resolve(
@@ -6,7 +6,7 @@ const updateBinaryPath = path.resolve(
   path.join('..', '..', '..', '..', 'deployment', 'update')
 );
 
-const installer = () => (
+const installer = () =>
   new Promise((resolve, reject) => {
     exec(
       updateBinaryPath,
@@ -14,14 +14,13 @@ const installer = () => (
       (error, stdout, stderr) => {
         const response = stdout + stderr;
 
-        if(error && error.code > 1) {
+        if (error && error.code > 1) {
           reject(response);
         } else {
           resolve(response);
         }
       }
     );
-  })
-);
+  });
 
 module.exports = installer;

--- a/services/setup/lib/paths-list/index.js
+++ b/services/setup/lib/paths-list/index.js
@@ -2,11 +2,10 @@ const fs = require('fs');
 const { readDir } = require('../fs');
 const pathLib = require('path');
 
-const isDirectory = (rootPath) => (path) => (
-  fs.statSync(pathLib.join(rootPath, path)).isDirectory()
-);
+const isDirectory = rootPath => path =>
+  fs.statSync(pathLib.join(rootPath, path)).isDirectory();
 
-const isNotHidden = (path) => path[0] !== ".";
+const isNotHidden = path => path[0] !== '.';
 
 const pathsList = async ({ rootPath, ignore = [] }) => {
   const paths = await readDir(rootPath);

--- a/services/setup/lib/resolve-relative/index.js
+++ b/services/setup/lib/resolve-relative/index.js
@@ -1,7 +1,6 @@
 const path = require('path');
 
-const resolveRelative = rootPath => relativePath => (
-  path.resolve(rootPath, relativePath)
-);
+const resolveRelative = rootPath => relativePath =>
+  path.resolve(rootPath, relativePath);
 
 module.exports = resolveRelative;

--- a/services/setup/lib/services/index.js
+++ b/services/setup/lib/services/index.js
@@ -7,7 +7,7 @@ const services = ({ path, available }) => {
       const files = await fs.readDir(path);
 
       return files;
-    } catch(err) {
+    } catch (err) {
       console.error('services read error:', err);
 
       return [];
@@ -19,27 +19,23 @@ const services = ({ path, available }) => {
 
     return available.map(p => ({
       name: p,
-      active: active.includes(p),
+      active: active.includes(p)
     }));
   };
 
   const set = async (paths = []) => {
     const existing = await current();
 
-    const pendingDelete = existing.filter(p => (
-      !paths.includes(p)
-    ));
+    const pendingDelete = existing.filter(p => !paths.includes(p));
 
-    const pendingCreate = paths.filter(p => (
-      !existing.includes(p)
-    ));
+    const pendingCreate = paths.filter(p => !existing.includes(p));
 
-    pendingDelete.forEach(async (p) => {
+    pendingDelete.forEach(async p => {
       const fullPath = join(path, p);
       await fs.unlink(fullPath);
     });
 
-    pendingCreate.forEach(async (p) => {
+    pendingCreate.forEach(async p => {
       const fullPath = join(path, p);
       await fs.open(fullPath, 'w');
     });

--- a/services/speech/src/emoji.js
+++ b/services/speech/src/emoji.js
@@ -1,3 +1,3 @@
-const replaceEmojiWithDescriptions = require("emoji-describe");
+const replaceEmojiWithDescriptions = require('emoji-describe');
 
-module.exports = (str = "") => replaceEmojiWithDescriptions(str);
+module.exports = (str = '') => replaceEmojiWithDescriptions(str);

--- a/services/speech/src/handleMessage.js
+++ b/services/speech/src/handleMessage.js
@@ -1,4 +1,4 @@
-const replaceEmoji = require("./emoji");
+const replaceEmoji = require('./emoji');
 
 const actions = {
   speak: async (speech, broker, topic, payload) => {
@@ -15,7 +15,7 @@ const actions = {
   },
   listVoices: async (speech, broker) => {
     broker.publish({
-      topic: "speech/event/availablevoices",
+      topic: 'speech/event/availablevoices',
       payload: {
         voices: await speech.listVoices()
       }
@@ -28,16 +28,16 @@ module.exports = (speech, broker) => async ({ topic, payload }) => {
 
   try {
     switch (topic) {
-      case "speech/command/speak":
+      case 'speech/command/speak':
         action = actions.speak;
         break;
-      case "speech/command/listvoices":
+      case 'speech/command/listvoices':
         action = actions.listVoices;
         break;
     }
 
     action(speech, broker, topic, payload);
   } catch (e) {
-    console.log("Error handling action", e);
+    console.log('Error handling action', e);
   }
 };

--- a/services/speech/src/main.js
+++ b/services/speech/src/main.js
@@ -1,9 +1,9 @@
-const createWebSocket = require("websocket").default;
+const createWebSocket = require('websocket').default;
 
-const log = require("debug")("speechd:main");
+const log = require('debug')('speechd:main');
 
-const connectToSpeechd = require("./speechd");
-const handleMessage = require("./handleMessage");
+const connectToSpeechd = require('./speechd');
+const handleMessage = require('./handleMessage');
 
 const autoSpawn = !!process.env.NO_AUTO_SPAWN;
 
@@ -12,13 +12,13 @@ const main = async () => {
     const speech = await connectToSpeechd({ autoSpawn: !autoSpawn });
     const broker = createWebSocket();
 
-    log("Connected to WebSocket");
+    log('Connected to WebSocket');
 
-    broker.subscribe(new RegExp("speech/.*"), handleMessage(speech, broker));
+    broker.subscribe(new RegExp('speech/.*'), handleMessage(speech, broker));
 
-    speech.speak("Hello");
+    speech.speak('Hello');
   } catch (e) {
-    console.log("Error:", e);
+    console.log('Error:', e);
   }
 };
 

--- a/services/speech/src/speechd/connect.js
+++ b/services/speech/src/speechd/connect.js
@@ -1,8 +1,8 @@
-const net = require("net");
+const net = require('net');
 
-const connectToSocket = require("./connectToSocket");
-const spawnServer = require("./spawnServer");
-const { ConnectionError } = require("./errors");
+const connectToSocket = require('./connectToSocket');
+const spawnServer = require('./spawnServer');
+const { ConnectionError } = require('./errors');
 
 const connect = async ({ autoSpawn = true, ...params } = {}) => {
   let connection = null;

--- a/services/speech/src/speechd/connectToSocket.js
+++ b/services/speech/src/speechd/connectToSocket.js
@@ -1,16 +1,16 @@
-const net = require("net");
-const debug = require("debug");
-const { EventEmitter } = require("events");
+const net = require('net');
+const debug = require('debug');
+const { EventEmitter } = require('events');
 
-const { ConnectionError } = require("./errors");
+const { ConnectionError } = require('./errors');
 
 const log = {
-  connect: debug("speechd:socket:connect"),
-  send: debug("speechd:socket:send"),
-  receive: debug("speechd:socket:receive")
+  connect: debug('speechd:socket:connect'),
+  send: debug('speechd:socket:send'),
+  receive: debug('speechd:socket:receive')
 };
 
-const { getPort } = require("./environment");
+const { getPort } = require('./environment');
 
 module.exports = ({ host = null, port = getPort() } = {}) => {
   const api = new EventEmitter();
@@ -18,9 +18,9 @@ module.exports = ({ host = null, port = getPort() } = {}) => {
 
   log.connect(`Connect to ${host}:${port}`);
 
-  socket.on("data", data => {
+  socket.on('data', data => {
     log.receive(data.toString());
-    api.emit("message", data.toString());
+    api.emit('message', data.toString());
   });
 
   api.send = (...params) => {
@@ -29,12 +29,12 @@ module.exports = ({ host = null, port = getPort() } = {}) => {
   };
 
   return new Promise((resolve, reject) => {
-    socket.on("connect", () => {
+    socket.on('connect', () => {
       resolve(api);
     });
 
-    socket.on("error", e => {
-      const isConnectionError = ["ENOENT", "ECONNREFUSED"].includes(e.code);
+    socket.on('error', e => {
+      const isConnectionError = ['ENOENT', 'ECONNREFUSED'].includes(e.code);
       const error = isConnectionError ? new ConnectionError() : e;
       reject(error);
     });

--- a/services/speech/src/speechd/environment.js
+++ b/services/speech/src/speechd/environment.js
@@ -1,7 +1,7 @@
-const { promisify } = require("util");
-const exec = promisify(require("child_process").exec);
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
 
-const { ExecutableNotFoundError } = require("./errors");
+const { ExecutableNotFoundError } = require('./errors');
 
 const getExecutablePath = async () => {
   try {

--- a/services/speech/src/speechd/errors.js
+++ b/services/speech/src/speechd/errors.js
@@ -1,12 +1,12 @@
 class ConnectionError extends Error {
   constructor() {
-    super("Cannot connect to speech-dispatcher server");
+    super('Cannot connect to speech-dispatcher server');
   }
 }
 
 class ExecutableNotFoundError extends Error {
   constructor() {
-    super("speech-dispatcher not found on PATH");
+    super('speech-dispatcher not found on PATH');
     this.message =
       "The command 'which speech-dispatcher' did not return the executable";
   }

--- a/services/speech/src/speechd/index.js
+++ b/services/speech/src/speechd/index.js
@@ -1,5 +1,5 @@
-const connect = require("./connect");
-const Protocol = require("./protocol");
+const connect = require('./connect');
+const Protocol = require('./protocol');
 
 module.exports = async (...params) => {
   const connection = await connect(...params);

--- a/services/speech/src/speechd/protocol/index.js
+++ b/services/speech/src/speechd/protocol/index.js
@@ -1,6 +1,6 @@
-const parseReply = require("./parseReply");
+const parseReply = require('./parseReply');
 
-const LINE_ENDING = "\r\n";
+const LINE_ENDING = '\r\n';
 
 class Protocol {
   constructor(connection) {
@@ -15,7 +15,7 @@ class Protocol {
         const response = this._parser(message);
         resolve(response);
       };
-      this._connection.once("message", handleResponse);
+      this._connection.once('message', handleResponse);
 
       // Send command and resolve returned promise with
       // the response
@@ -24,7 +24,7 @@ class Protocol {
   }
 
   async listVoices() {
-    const response = await this.send("LIST VOICES");
+    const response = await this.send('LIST VOICES');
     return response.lines.map(({ content }) => content);
   }
 
@@ -34,14 +34,14 @@ class Protocol {
   }
 
   async getVoiceType() {
-    const response = await this.send("GET VOICE_TYPE");
+    const response = await this.send('GET VOICE_TYPE');
     return response.lines[0].content;
   }
 
   async speak(utterance) {
-    await this.send("SPEAK");
+    await this.send('SPEAK');
     this.send(utterance);
-    this.send(".");
+    this.send('.');
   }
 }
 

--- a/services/speech/src/speechd/protocol/parseReply.js
+++ b/services/speech/src/speechd/protocol/parseReply.js
@@ -13,7 +13,7 @@ module.exports = lineEnding =>
 
         if (matches) {
           const [_, statusCode, replyOrResult, content] = matches;
-          const isResult = replyOrResult === " ";
+          const isResult = replyOrResult === ' ';
 
           const obj = {
             code: statusCode,

--- a/services/speech/src/speechd/spawnServer.js
+++ b/services/speech/src/speechd/spawnServer.js
@@ -1,18 +1,18 @@
-const { promisify } = require("util");
-const exec = promisify(require("child_process").exec);
-const debug = require("debug")("speechd:spawn");
-const { getPort, getExecutablePath } = require("./environment");
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+const debug = require('debug')('speechd:spawn');
+const { getPort, getExecutablePath } = require('./environment');
 
 module.exports = async () => {
   const path = await getExecutablePath();
   const command = `${path} --communication-method=inet_socket --port=${getPort()}`;
 
-  debug("spawn exec: ", command);
+  debug('spawn exec: ', command);
 
   try {
     return await exec(command);
   } catch (e) {
-    debug("Caught error spawning server: ", e);
+    debug('Caught error spawning server: ', e);
     return null;
   }
 };

--- a/shared/create-new-app/index.js
+++ b/shared/create-new-app/index.js
@@ -6,18 +6,16 @@ const path = require('path');
 const rootPath = path.resolve(__dirname, '../../apps');
 const templatePath = path.resolve(__dirname, './templates');
 
-const copyFile = (appPath) => (fileName) => {
+const copyFile = appPath => fileName => {
   const destination = path.join(appPath, fileName);
   const source = path.join(templatePath, fileName);
 
   return fs.copyFileSync(source, destination);
 };
 
-const touch = (path) => (
-  fs.closeSync(fs.openSync(path, 'w'))
-);
+const touch = path => fs.closeSync(fs.openSync(path, 'w'));
 
-const createNewApp = async (name) => {
+const createNewApp = async name => {
   const appPath = path.join(rootPath, name);
   const srcPath = path.join(appPath, 'src');
   const copy = copyFile(srcPath);
@@ -30,19 +28,18 @@ const createNewApp = async (name) => {
   fs.mkdirSync(path.join(srcPath, 'lib'));
   touch(path.join(srcPath, 'lib', '.gitkeep'));
 
-  ['internal.html', 'internal.js', 'external.html', 'external.js'].forEach(copy);
-
-  await exec(
-    'npm init --yes > /dev/null',
-    { ...process.env, cwd: appPath }
+  ['internal.html', 'internal.js', 'external.html', 'external.js'].forEach(
+    copy
   );
+
+  await exec('npm init --yes > /dev/null', { ...process.env, cwd: appPath });
 
   console.log(`Created new application in ${appPath}`);
 };
 
 const appName = process.argv[2];
 
-if(!appName) {
+if (!appName) {
   console.log('USAGE: npm run create-app app-name');
   process.exit(0);
 }

--- a/shared/create-new-app/templates/external.js
+++ b/shared/create-new-app/templates/external.js
@@ -1,4 +1,4 @@
-const appName = window.location.pathname.replace(/\//g,'');
+const appName = window.location.pathname.replace(/\//g, '');
 
 const main = async () => {
   const websocket = createWebsocket();
@@ -8,16 +8,13 @@ const main = async () => {
 
     websocket.publish({
       topic: `${appName}/event/ready`,
-      payload: { msg: 'External app ready!' },
+      payload: { msg: 'External app ready!' }
     });
   });
 
-  websocket.subscribe(
-    new RegExp(`${appName}/.*`),
-    ({ topic, payload }) => {
-      console.log('Recieved message', topic, payload);
-    }
-  );
+  websocket.subscribe(new RegExp(`${appName}/.*`), ({ topic, payload }) => {
+    console.log('Recieved message', topic, payload);
+  });
 
   console.log('External app loaded');
 };

--- a/shared/create-new-app/templates/internal.js
+++ b/shared/create-new-app/templates/internal.js
@@ -1,4 +1,4 @@
-const appName = window.location.pathname.replace(/\//g,'');
+const appName = window.location.pathname.replace(/\//g, '');
 
 const main = async () => {
   const websocket = createWebsocket();
@@ -8,16 +8,13 @@ const main = async () => {
 
     websocket.publish({
       topic: `${appName}/event/ready`,
-      payload: { msg: 'Internal app ready!' },
+      payload: { msg: 'Internal app ready!' }
     });
   });
 
-  websocket.subscribe(
-    new RegExp(`${appName}/.*`),
-    ({ topic, payload }) => {
-      console.log('Recieved message', topic, payload);
-    }
-  );
+  websocket.subscribe(new RegExp(`${appName}/.*`), ({ topic, payload }) => {
+    console.log('Recieved message', topic, payload);
+  });
 
   console.log('Internal app loaded');
 };

--- a/shared/websocket/index.js
+++ b/shared/websocket/index.js
@@ -1,7 +1,7 @@
 const WebSocket =
-  typeof window == "undefined" ? require("ws") : window.WebSocket;
+  typeof window == 'undefined' ? require('ws') : window.WebSocket;
 const hostname =
-  typeof window == "undefined" ? "127.0.0.1" : window.location.hostname;
+  typeof window == 'undefined' ? '127.0.0.1' : window.location.hostname;
 
 const defaultURL = `ws://${hostname}:8000`;
 const topicRegexp = /^([a-z]+[a-z0-9-]*)\/(command|event)\/([a-z]+[a-z0-9-]*)$/;
@@ -104,12 +104,12 @@ const createWebsocket = (opts = {}) => {
   };
 
   const onClose = err => {
-    log("Websocket disconnected", err);
+    log('Websocket disconnected', err);
     setTimeout(connect, 500);
   };
 
   const onError = err => {
-    log("Websocket error", err);
+    log('Websocket error', err);
   };
 
   const subscribe = (topic, cb) => {
@@ -135,12 +135,12 @@ const createWebsocket = (opts = {}) => {
     log(`Connecting to ${url}`);
 
     ws = new WebSocket(url);
-    ws.addEventListener("message", onMessage);
-    ws.addEventListener("close", onClose);
-    ws.addEventListener("error", onError);
+    ws.addEventListener('message', onMessage);
+    ws.addEventListener('close', onClose);
+    ws.addEventListener('error', onError);
 
     ready = new Promise(resolve => {
-      ws.addEventListener("open", resolve);
+      ws.addEventListener('open', resolve);
     }).then(() => log(`Connected to ${url}`));
   };
 
@@ -151,4 +151,4 @@ const createWebsocket = (opts = {}) => {
 
 (function(exports) {
   exports.default = createWebsocket;
-})(typeof exports === "undefined" ? (this.share = {}) : exports);
+})(typeof exports === 'undefined' ? (this.share = {}) : exports);


### PR DESCRIPTION
Formats all code and adds an `npm run format-code` task to do it in future.

I've added `.prettierrc` to prefer single quotes around non-JSX strings.

I've quickly smoke-tested this and it seems to work. 