### PR TITLE
Add homepage to external manager server

### DIFF
--- a/services/manager/lib/io/http/homepage.html
+++ b/services/manager/lib/io/http/homepage.html
@@ -1,0 +1,29 @@
+<html>
+  <head><title>Radio Neue</title></head>
+  <body>
+    <h1>Homepage</h1>
+
+    <ul id="apps">
+    </ul>
+    <script>
+      const list = document.getElementById('apps');
+
+      fetch('/apps')
+        .then((res) => res.json())
+        .then((apps) => {
+          apps.forEach((a) => {
+            list.appendChild(buildItem(a));
+          });
+        });
+
+      const buildItem = (app) => {
+        const template = document.createElement('template');
+        const url = `//${window.location.hostname}:${app.port}${app.path || '/'}`;
+
+        template.innerHTML = `<li><a href="${url}">${app.name}</a></li>`;
+
+        return template.content.firstChild;
+      };
+    </script>
+  </body>
+</html>

--- a/services/manager/lib/io/http/homepage.js
+++ b/services/manager/lib/io/http/homepage.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const portsPath = path.resolve(
+  __dirname,
+  '../../../../../deployment/systemd/ports.env'
+);
+
+const readPorts = () => {
+  var contents = fs.readFileSync(portsPath, 'utf8');
+
+  return contents.split("\n").reduce((acc, line) => {
+    const [key, value] = line.split('=');
+
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {});
+};
+
+const appList = (appObj) => {
+  const ports = readPorts();
+  const apps = appObj.map( a => a.name ).sort();
+
+  const internalApps = apps.map((a) => ({
+    name: `${a} (internal)`,
+    port: ports.MANAGER_INTERNAL_PORT,
+    path: `/${a}`,
+  }))
+
+  const externalApps = apps.map((a) => ({
+    name: `${a} (external)`,
+    port: ports.MANAGER_EXTERNAL_PORT,
+    path: `/${a}`,
+  }))
+
+  return [
+    { name: 'Setup', port: ports.SETUP_PORT },
+    { name: 'Debug', port: ports.DEBUG_PORT },
+    ...internalApps,
+    ...externalApps,
+  ];
+};
+
+const mountHomepage = (apps, server) => {
+  server.get('/', (_req, res) => res.sendFile('homepage.html', { root: __dirname }));
+  server.get('/apps', (_req, res) => res.json(appList(apps)));
+};
+
+module.exports = mountHomepage;

--- a/services/manager/lib/io/http/homepage.js
+++ b/services/manager/lib/io/http/homepage.js
@@ -1,51 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-
-const portsPath = path.resolve(
-  __dirname,
-  '../../../../../deployment/systemd/ports.env'
-);
-
-const readPorts = () => {
-  var contents = fs.readFileSync(portsPath, 'utf8');
-
-  return contents.split("\n").reduce((acc, line) => {
-    const [key, value] = line.split('=');
-
-    return {
-      ...acc,
-      [key]: value,
-    };
-  }, {});
-};
-
-const appList = (appObj) => {
-  const ports = readPorts();
-  const apps = appObj.map( a => a.name ).sort();
-
-  const internalApps = apps.map((a) => ({
-    name: `${a} (internal)`,
-    port: ports.MANAGER_INTERNAL_PORT,
-    path: `/${a}`,
-  }))
-
-  const externalApps = apps.map((a) => ({
-    name: `${a} (external)`,
-    port: ports.MANAGER_EXTERNAL_PORT,
-    path: `/${a}`,
-  }))
-
-  return [
-    { name: 'Setup', port: ports.SETUP_PORT },
-    { name: 'Debug', port: ports.DEBUG_PORT },
-    ...internalApps,
-    ...externalApps,
-  ];
-};
-
-const mountHomepage = (apps, server) => {
-  server.get('/', (_req, res) => res.sendFile('homepage.html', { root: __dirname }));
-  server.get('/apps', (_req, res) => res.json(appList(apps)));
+const mountHomepage = (_apps, server) => {
+  server.get('/', (_req, res) =>
+    res.sendFile('homepage.html', { root: __dirname })
+  );
 };
 
 module.exports = mountHomepage;

--- a/services/manager/lib/io/http/index.js
+++ b/services/manager/lib/io/http/index.js
@@ -5,6 +5,8 @@ const serveIndex = require('serve-index');
 
 const logger = require('../logger');
 
+const mountHomepage = require('./homepage');
+
 const directoryListing = ({ fileList, directory }, callback) => {
   const listing = fileList
     .filter(({ name }) => name[0] != '.')
@@ -27,18 +29,6 @@ const mountApp = ({ server, name, path, index }) => {
     template: directoryListing
   });
   server.use(pathLib.join(httpPath, 'assets'), serveAssets, listAssets);
-};
-
-const mountAppList = (apps, server) => {
-  const appNames = apps.map(a => a.name);
-
-  server.get('/apps', (req, res) =>
-    res.json({
-      apps: appNames
-    })
-  );
-
-  logger.log('http', 'Mounted apps', appNames);
 };
 
 const startServer = (server, port, name) => {
@@ -65,6 +55,8 @@ const mountExternal = (apps, port) => {
     mountApp({ server, name, path, index: 'external.html' });
   });
 
+  mountAppList(apps, server);
+  mountHomepage(apps, server);
   mountWebsocket(server);
 
   startServer(server, port, 'Public');
@@ -73,13 +65,14 @@ const mountExternal = (apps, port) => {
 const mountInternal = (apps, port, publicPath) => {
   const server = express();
 
-  mountAppList(apps, server);
+  logger.log('http', 'Mounted apps', apps.map( a => a.name ));
 
   apps.map(({ name, path }) =>
     mountApp({ server, name, path, index: 'internal.html' })
   );
 
   mountWebsocket(server);
+  mountAppList(apps, server);
 
   server.use(express.static(publicPath));
 

--- a/services/manager/lib/io/http/index.js
+++ b/services/manager/lib/io/http/index.js
@@ -5,6 +5,7 @@ const serveIndex = require('serve-index');
 
 const logger = require('../logger');
 
+const mountAppList = require('./list');
 const mountHomepage = require('./homepage');
 
 const directoryListing = ({ fileList, directory }, callback) => {

--- a/services/manager/lib/io/http/list.js
+++ b/services/manager/lib/io/http/list.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const portsPath = path.resolve(
+  __dirname,
+  '../../../../../deployment/systemd/ports.env'
+);
+
+const readPorts = () => {
+  var contents = fs.readFileSync(portsPath, 'utf8');
+
+  return contents.split('\n').reduce((acc, line) => {
+    const [key, value] = line.split('=');
+
+    return {
+      ...acc,
+      [key]: value
+    };
+  }, {});
+};
+
+module.exports = (appObj, server) => {
+  const ports = readPorts();
+  const apps = appObj.map(a => a.name).sort();
+
+  const list = apps.map(a => ({
+    name: `${a}`,
+    type: 'app',
+    internal: {
+      path: `/${a}`,
+      port: ports.MANAGER_INTERNAL_PORT
+    },
+    external: {
+      path: `/${a}`,
+      port: ports.MANAGER_EXTERNAL_PORT
+    },
+    path: `/${a}`
+  }));
+
+  const all = [
+    { name: 'Setup', external: { port: ports.SETUP_PORT }, type: 'service' },
+    { name: 'Debug', external: { port: ports.DEBUG_PORT }, type: 'service' },
+    ...list
+  ];
+
+  server.get('/apps', (_req, res) => res.json(all));
+};

--- a/services/manager/public/index.html
+++ b/services/manager/public/index.html
@@ -24,8 +24,8 @@
     }
 
     async function getApps() {
-      const config = await fetch('/apps').then(res => res.json());
-      return config.apps;
+      const apps = await fetch('/apps').then(res => res.json());
+      return apps.filter(({ type }) => type === 'app');
     }
 
     function openApps(apps) {
@@ -33,7 +33,7 @@
 
       return apps.map(function (app) {
         const url = new URL(window.location);
-        url.pathname = app;
+        url.pathname = app.external.path;
 
         return mountAppUrlAtRoot(app, url, rootElement);
       });


### PR DESCRIPTION
Contains a list of apps and services available on the pi, accessible from `/` within the external port of the manager server. Since this is mapped to port `80` on the pi using `iptables`, this page is mounted as `raspberrypi.local`. 🤓 

Fixes #89 #79