### PR TITLE
Allow npm to run when running as root (fixes #90)

### DIFF
--- a/deployment/update
+++ b/deployment/update
@@ -39,7 +39,7 @@ const findApplicableDirectories = async rootDir => {
 
 const install = async ({ name, path }) => {
   try {
-    await exec(`npm install --production`, {
+    await exec(`npm install --unsafe-perm --production`, {
       cwd: path,
       env: { ...process.env, JOBS: "max" }
     });


### PR DESCRIPTION
When running as the root user, the `--unsafe-perms` flag needs to be used so that NPM can install node-serialport and other native modules.