### PR TITLE
LED matrix

### DIFF
--- a/services/physical/config/led-matrix-config.example.json
+++ b/services/physical/config/led-matrix-config.example.json
@@ -1,0 +1,14 @@
+{
+  "ledmatrix": [
+    {
+      "id": "1",
+      "config": {
+        "pins": {
+          "data": "GPIO20",
+          "clock": "GPIO21",
+          "cs": "GPIO16"
+        }
+      }
+    }
+  ]
+}

--- a/services/physical/config/physical-config.example.json
+++ b/services/physical/config/physical-config.example.json
@@ -1,0 +1,82 @@
+{
+  "Button": [
+    {
+      "id": "next",
+      "config": {
+        "pin": 2,
+        "isPullup": true,
+        "invert": true
+      }
+    },
+    {
+      "id": "magic",
+      "config": {
+        "pin": 7,
+        "isPullup": false,
+        "isPulldown": true,
+        "invert": false
+      }
+    },
+    {
+      "id": "power",
+      "config": {
+        "pin": 3,
+        "isPullup": false,
+        "isPulldown": true,
+        "invert": false
+      }
+    }
+  ],
+  "Encoder": [
+    {
+      "id": "power",
+      "config": {
+        "pins": {
+          "a": 5,
+          "b": 4
+        },
+        "pullResistors": {
+          "a": "up",
+          "b": "up"
+        }
+      }
+    },
+    {
+      "id": "magic",
+      "config": {
+        "pins": {
+          "a": 8,
+          "b": 9
+        },
+        "pullResistors": {
+          "a": "up",
+          "b": "up"
+        }
+      }
+    }
+  ],
+  "Led.RGB": [
+    {
+      "id": "magic",
+      "config": {
+        "pins": {
+          "red": 12,
+          "green": 13,
+          "blue": 14
+        },
+        "isAnode": true
+      }
+    },
+    {
+      "id": "power",
+      "config": {
+        "pins": {
+          "red": 6,
+          "green": 10,
+          "blue": 11
+        },
+        "isAnode": true
+      }
+    }
+  ]
+}

--- a/services/physical/lib/factories/Led.Matrix.js
+++ b/services/physical/lib/factories/Led.Matrix.js
@@ -6,7 +6,7 @@ module.exports = function(spec, routable) {
 
   const matrix = five.Led.Matrix(Object.assign({ id: id }, config));
 
-  routable.on('request', function(req) {
+  routable.on('draw', function(req) {
     if (req.data && Array.isArray(req.data)) {
       try {
         matrix.draw(req.data);

--- a/services/physical/lib/factories/Led.Matrix.js
+++ b/services/physical/lib/factories/Led.Matrix.js
@@ -1,0 +1,18 @@
+const five = require('johnny-five');
+
+module.exports = function(spec, routable) {
+  const id = spec.id;
+  const config = spec.config;
+
+  const matrix = five.Led.Matrix(Object.assign({ id: id }, config));
+
+  routable.on('request', function(req) {
+    if (req.data && Array.isArray(req.data)) {
+      try {
+        matrix.draw(req.data);
+      } catch (error) {
+        console.error(id, error);
+      }
+    }
+  });
+};

--- a/services/physical/lib/factories/index.js
+++ b/services/physical/lib/factories/index.js
@@ -2,5 +2,6 @@ module.exports = {
   button: require('./Button'),
   capacitive: require('./Capacitive'),
   encoder: require('./Encoder'),
+  ledmatrix: require('./Led.Matrix'),
   ledrgb: require('./Led.RGB')
 };


### PR DESCRIPTION
This adds support for the [Johnny-Five `Led.Matrix`](http://johnny-five.io/api/led.matrix/) component type to the `physical` service and makes it addressable via the WebSocket broker.

Sending `physical/command/ledmatrix-id-draw` with a payload:

```js
{
  data:  [
    "01100110",
    "10011001",
    "10000001",
    "10000001",
    "01000010",
    "00100100",
    "00011000",
    "00000000"
  ]
}
```

Will draw this:

![img_4988](https://user-images.githubusercontent.com/1762/39133577-d2aa2b62-4714-11e8-96f7-377b3c56f434.jpg)
