### PR TITLE
Runtime config for apps

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -69,6 +69,8 @@ echo "*** Radiodan"
 mkdir -p /opt/radiodan
 mkdir -p /opt/radiodan/processes/services
 touch /opt/radiodan/processes/services/{downloader,speech}
+mkdir -p /opt/radiodan/config
+echo "{}" /opt/radiodan/config/env.json
 
 cd /opt/radiodan
 git clone https://github.com/andrewn/neue-radio rde

--- a/deployment/provision
+++ b/deployment/provision
@@ -140,6 +140,15 @@ apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-he
    read only = no
    force user = pi
    force group = pi
+
+[config]
+   path = /opt/radiodan/config
+   browsable = yes
+   public = yes
+   writable = yes
+   read only = no
+   force user = pi
+   force group = pi
 EOF
 
 /usr/bin/yes pi | smbpasswd -a -s pi

--- a/deployment/systemd/manager-web-server.service
+++ b/deployment/systemd/manager-web-server.service
@@ -5,8 +5,10 @@ Description=Radio app manager web server
 EnvironmentFile=/opt/radiodan/rde/deployment/systemd/ports.env
 # The leading hyphen in the below path means that this file is optional
 EnvironmentFile=-/opt/radiodan/rde/services/setup/tmp/apps
+Environment=CONFIG_PATH=/opt/radiodan/config/env.json
 WorkingDirectory=/opt/radiodan/rde/services/manager
 ExecStart=/usr/bin/env \
+          CONFIG_PATH=${CONFIG_PATH}
           INTERNAL_PORT=${MANAGER_INTERNAL_PORT} \
           EXTERNAL_PORT=${MANAGER_EXTERNAL_PORT} \
           WEBSOCKET_PORT=${MANAGER_WEBSOCKET_PORT} \

--- a/services/manager/lib/io/config/index.js
+++ b/services/manager/lib/io/config/index.js
@@ -1,10 +1,12 @@
-const { resolve } = require('path');
+const { join, resolve } = require('path');
 const { promisify } = require('util');
 const fs = require('fs');
 
 const readFile = promisify(fs.readFile);
 
-const configPath = resolve(process.env.CONFIG_PATH);
+const configPath = process.env.CONFIG_PATH
+  ? resolve(process.env.CONFIG_PATH)
+  : join(__dirname, '../../../../../env.json');
 
 module.exports = async () => {
   try {

--- a/services/manager/lib/io/config/index.js
+++ b/services/manager/lib/io/config/index.js
@@ -1,0 +1,16 @@
+const { resolve } = require('path');
+const { promisify } = require('util');
+const fs = require('fs');
+
+const readFile = promisify(fs.readFile);
+
+const configPath = resolve(process.env.CONFIG_PATH);
+
+module.exports = async () => {
+  try {
+    return JSON.parse(await readFile(configPath));
+  } catch (error) {
+    console.error('Error reading config: ', error);
+    return null;
+  }
+};

--- a/services/manager/lib/io/config/index.js
+++ b/services/manager/lib/io/config/index.js
@@ -13,6 +13,6 @@ module.exports = async () => {
     return JSON.parse(await readFile(configPath));
   } catch (error) {
     console.error('Error reading config: ', error);
-    return null;
+    return {};
   }
 };

--- a/services/manager/lib/io/http/config.js
+++ b/services/manager/lib/io/http/config.js
@@ -1,0 +1,7 @@
+const getConfig = require('../config');
+
+module.exports = server =>
+  server.get('/config', async (req, res) => {
+    const json = await getConfig();
+    res.json(json || {});
+  });

--- a/services/manager/lib/io/http/config.js
+++ b/services/manager/lib/io/http/config.js
@@ -2,6 +2,5 @@ const getConfig = require('../config');
 
 module.exports = server =>
   server.get('/config', async (req, res) => {
-    const json = await getConfig();
-    res.json(json || {});
+    res.json(await getConfig());
   });

--- a/services/manager/lib/io/http/index.js
+++ b/services/manager/lib/io/http/index.js
@@ -7,6 +7,7 @@ const logger = require('../logger');
 
 const mountAppList = require('./list');
 const mountHomepage = require('./homepage');
+const mountConfig = require('./config');
 
 const directoryListing = ({ fileList, directory }, callback) => {
   const listing = fileList
@@ -57,6 +58,7 @@ const mountExternal = (apps, port) => {
   });
 
   mountAppList(apps, server);
+  mountConfig(server);
   mountHomepage(apps, server);
   mountWebsocket(server);
 
@@ -66,14 +68,15 @@ const mountExternal = (apps, port) => {
 const mountInternal = (apps, port, publicPath) => {
   const server = express();
 
-  logger.log('http', 'Mounted apps', apps.map( a => a.name ));
+  logger.log('http', 'Mounted apps', apps.map(a => a.name));
 
   apps.map(({ name, path }) =>
     mountApp({ server, name, path, index: 'internal.html' })
   );
 
-  mountWebsocket(server);
   mountAppList(apps, server);
+  mountConfig(server);
+  mountWebsocket(server);
 
   server.use(express.static(publicPath));
 


### PR DESCRIPTION
This is a central file (called `env.json`) to store config that is not checked into version control. It's mounted at `/config` on the external and internal ports. It's similar in purpose to [Heroku's Config Vars](https://devcenter.heroku.com/articles/config-vars#setting-up-config-vars-for-a-deployed-application).

An example use case: an app that can provide different demos, the config file would be the place to configure which experience it would provide for particular deployment. 

I've exposed `/opt/radiodan/config` over Samba so `env.json` can be edited without having to ssh into the machine.

In the future we could also extend the `setup` service to read/write the file.