### PR TITLE
Do not echo newline when writing initial apps list

### DIFF
--- a/deployment/provision
+++ b/deployment/provision
@@ -92,7 +92,7 @@ systemctl enable serial
 systemctl enable setup
 
 # Enable radio app only
-echo "APP_PATH=/opt/radiodan/rde/apps/radio" > /opt/radiodan/rde/services/setup/tmp/apps
+echo -ne "APP_PATH=/opt/radiodan/rde/apps/radio" > /opt/radiodan/rde/services/setup/tmp/apps
 
 cd /opt/radiodan/rde
 echo "*** Pulse Audio system mode"


### PR DESCRIPTION
When the `apps` file contains a newline, the Setup service doesn't
seems to correctly detect which apps are enabled or not. This means
that initiall "radio" is not checked in the web UI even though it
is enabled.