### PR TITLE
Add check for pi platform when adding support apps to manager homepage

### DIFF
--- a/services/manager/lib/io/http/list.js
+++ b/services/manager/lib/io/http/list.js
@@ -37,11 +37,11 @@ module.exports = (appObj, server) => {
     path: `/${a}`
   }));
 
-  const all = [
+  const all = process.platform == 'linux' ? [
     { name: 'Setup', external: { port: ports.SETUP_PORT }, type: 'service' },
     { name: 'Debug', external: { port: ports.DEBUG_PORT }, type: 'service' },
     ...list
-  ];
+  ] : [...list];
 
   server.get('/apps', (_req, res) => res.json(all));
 };


### PR DESCRIPTION
A very naive approach. For the purposes of the hackday, we are
assuming that whenever this is being run on Linux, then this is the
Raspberry Pi, and therefore will have access to the setup and debug
services.

This is to prevent new developers not realising why certain apps are not
avaiable when running on their (presumably) MacBook Pro.

Fixes #118