### PR TITLE
Fix RFID problem for websockets

### DIFF
--- a/services/rfid/index.js
+++ b/services/rfid/index.js
@@ -1,12 +1,14 @@
 const { URL } = require('url');
+const ip = require('ip');
 
 const ws = require('./lib/ws');
 const rfid = require('./lib/rfid');
 const notify = require('./lib/notify');
 
 const port = process.env.PORT || 5002;
+const host = new URL(`http://${ip.address()}:${port}`);
 
-const send = ws().send;
+const send = ws({host}).send;
 const { error, presented, removed } = notify(send);
 
 // Start polling for cards


### PR DESCRIPTION
I was getting 

    pi@raspberrypi:/opt/radiodan/rde/services/rfid $ npm start

    > rfid-spi@1.0.0 start /opt/radiodan/rde/services/rfid
    > node index

    /opt/radiodan/rde/services/rfid/lib/ws.js:4
    const webSocket = ({ host }) => {
                     ^

    TypeError: Cannot destructure property `host` of 'undefined' or 'null'.


I suspect this is just older code that hasn't been updated. Updated with the equivalent from downloader and it works fine.